### PR TITLE
Fix deps

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,12 +7,23 @@ find_package(GTest CONFIG REQUIRED)
 find_package(GMock CONFIG REQUIRED)
 
 # https://docs.hunter.sh/en/latest/packages/pkg/Boost.html
-hunter_add_package(Boost)
-find_package(Boost CONFIG REQUIRED)
+hunter_add_package(Boost COMPONENTS filesystem random)
+find_package(Boost CONFIG REQUIRED filesystem random)
 
 # https://docs.hunter.sh/en/latest/packages/pkg/Microsoft.GSL.html
 hunter_add_package(Microsoft.GSL)
 find_package(Microsoft.GSL CONFIG REQUIRED)
 
+# https://www.openssl.org/
+hunter_add_package(OpenSSL)
+find_package(OpenSSL REQUIRED)
+
+# https://developers.google.com/protocol-buffers/
+hunter_add_package(Protobuf)
+find_package(Protobuf CONFIG REQUIRED)
+
+hunter_add_package(spdlog)
+find_package(spdlog CONFIG REQUIRED)
+
 hunter_add_package(libp2p)
-find_package(libp2p REQUIRED)
+find_package(libp2p CONFIG REQUIRED)


### PR DESCRIPTION
when adding a target from libp2p, for example, p2p::p2p_default_network, the project cannot be built, since some dependencies are missing.
This PR aims to fix this problem.