### PR TITLE
disable modernize-use-trailing-return-type check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          '-*,clang-analyzer-*,clang-diagnostic-*,readability-*,modernize-*,-modernize-use-trailing-return-type,boost-*,bugprone-*,cppcoreguidelines-*,google-*,hicpp-*,performance-*,readability-*,-google-readability-namespace-comments,-readability-inconsistent-declaration-parameter-name,-readability-braces-around-statements,-hicpp-signed-bitwise,-google-runtime-references,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-readability-magic-numbers,-hicpp-explicit-conversions,-hicpp-uppercase-literal-suffix,-readability-uppercase-literal-suffix,-hicpp-no-array-decay,-hicpp-special-member-functions,-bugprone-narrowing-conversions,-modernize-use-nodiscard,-google-readability-braces-around-statements,-hicpp-braces-around-statements,-bugprone-suspicious-semicolon,-readability-named-parameter,-hicpp-named-parameter,-readability-identifier-naming'
-WarningsAsErrors: 'modernize-*,-modernize-use-trailing-return-type,cppcoreguidelines-*,boost-*,performance-*,google-build-using-namespace,readability-else-after-return,google-readability-todo'
+WarningsAsErrors: 'modernize-*,cppcoreguidelines-*,boost-*,performance-*,google-build-using-namespace,readability-else-after-return,google-readability-todo'
 HeaderFilterRegex: 'core/.*\.hpp'
 AnalyzeTemporaryDtors: false
 FormatStyle:     .clang-format


### PR DESCRIPTION
This new doubtful check breaks the build.
I'm sure we don't need it in ordinary functions.