### PR TITLE
Fix LEB128 decode overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To clone repository execute
 git clone https://github.com/filecoin-project/cpp-filecoin.git
 cd cpp-filecoin
 git submodule update --init --recursive
+curl -sSf https://sh.rustup.rs | sh
 ```
 
 ## Development

--- a/core/codec/leb128/README.md
+++ b/core/codec/leb128/README.md
@@ -34,6 +34,6 @@ using fc::codec::leb128::encode;
 using fc::codec::leb128::decode;
 
 T data;
-OUTCOME_TRY(encoded, encode(data));
+std::vector<uint8_t> encoded = encode(data);
 OUTCOME_TRY(decoded, decode(encoded));
 ```

--- a/core/codec/leb128/README.md
+++ b/core/codec/leb128/README.md
@@ -13,8 +13,7 @@ using fc::codec::leb128::LEB128EncodeStream;
 LEB128EncodeStream s;
 uint64_t data = 481516u;
 s << data;
-std::vector<uint8_t> output; // Byte-vector for encoded data
-s >> output;
+std::vector<uint8_t> encoded = s.data();
 ```
 
 ## LEB128DecodeStream

--- a/core/codec/leb128/README.md
+++ b/core/codec/leb128/README.md
@@ -1,32 +1,40 @@
-# LEB128 codec
-> Primitive types encode/decode user guide
+# LEB128 codec C++ implementation
 
-### Encoding stream
+Encoding and decoding the following data types:
+* `uint8_t, uint16_t, uint32_t, uint64_t`
+* `uint128_t, uint256_t, uint512_t, uint1024_t` (boost::multiprecision) 
 
+## LEB128EncodeStream
+Class LEB128EncodeStream is in charge of encoding data
 ```c
 #include "codec/leb128/leb128_encode_stream.hpp"
 using fc::codec::leb128::LEB128EncodeStream;
 
-LEB128EncodeStream encoder;
-T data;                      // Some numeric type to encode
-encoder << data;
+LEB128EncodeStream s;
+uint64_t data = 481516u;
+s << data;
 std::vector<uint8_t> output; // Byte-vector for encoded data
-encoder >> output;
+s >> output;
 ```
 
-### Decoding stream
-
+## LEB128DecodeStream
+Class LEB128 is in charge of decoding data
 ```c
 #include "codec/leb128/leb128_decode_stream.hpp"
 using fc::codec::leb128::LEB128DecodeStream;
 
-std::vector<uint8_t> encoded; // Byte-vector with encoded data
-LEB128DecodeStream decoder{ encoded };
-T data;                       // Some numeric type for decoded data
-decoder >> data;              // Decode can throw exception, use here try/catch
+std::vector<uint8_t> encoded{0x88, 0xA1, 0x02};
+LEB128DecodeStream s{ encoded };
+uint16_t data;
+try {
+  s >> data;
+} catch (std::exception &) {
+  // handle error
+}
 ```
 
-### Free functions
+## Convenience functions
+Wrappers around encode/decode streams
 
 ```c
 #include "codec/leb128/leb128.hpp"

--- a/core/codec/leb128/README.md
+++ b/core/codec/leb128/README.md
@@ -1,0 +1,39 @@
+# LEB128 codec
+> Primitive types encode/decode user guide
+
+### Encoding stream
+
+```c
+#include "codec/leb128/leb128_encode_stream.hpp"
+using fc::codec::leb128::LEB128EncodeStream;
+
+LEB128EncodeStream encoder;
+T data;                      // Some numeric type to encode
+encoder << data;
+std::vector<uint8_t> output; // Byte-vector for encoded data
+encoder >> output;
+```
+
+### Decoding stream
+
+```c
+#include "codec/leb128/leb128_decode_stream.hpp"
+using fc::codec::leb128::LEB128DecodeStream;
+
+std::vector<uint8_t> encoded; // Byte-vector with encoded data
+LEB128DecodeStream decoder{ encoded };
+T data;                       // Some numeric type for decoded data
+decoder >> data;              // Decode can throw exception, use here try/catch
+```
+
+### Free functions
+
+```c
+#include "codec/leb128/leb128.hpp"
+using fc::codec::leb128::encode;
+using fc::codec::leb128::decode;
+
+T data;
+OUTCOME_TRY(encoded, encode(data));
+OUTCOME_TRY(decoded, decode(encoded));
+```

--- a/core/codec/leb128/README.md
+++ b/core/codec/leb128/README.md
@@ -44,3 +44,20 @@ T data;
 std::vector<uint8_t> encoded = encode(data);
 OUTCOME_TRY(decoded, decode(encoded));
 ```
+
+## Custom types
+Define custom << and >> operators to provide support for custom types. Note: LEB128 codec supports encoding of the one number per one time
+
+```c
+struct MyType {
+    uint64_t data;
+};
+
+LEB128EncodeStream &operator<<(LEB128EncodeStream &s, const MyType &t) {
+  return s << t.data;
+}
+
+LEB128DecodeStream &operator>>(LEB128DecodeStream &s, MyType &t) {
+  return s >> t.data;
+}
+```

--- a/core/codec/leb128/leb128.hpp
+++ b/core/codec/leb128/leb128.hpp
@@ -43,12 +43,11 @@ namespace fc::codec::leb128 {
     if (input.empty()) {
       return outcome::failure(LEB128DecodeError::INPUT_EMPTY);
     }
-    const size_t requestedCapacity = input.size() * 7 - 7;
-    constexpr size_t currentCapacity = sizeof(T) * 8;
-    if (requestedCapacity > currentCapacity) {
+    try {
+      decoder >> data;
+    } catch (std::exception&) {
       return outcome::failure(LEB128DecodeError::INPUT_TOO_BIG);
     }
-    decoder >> data;
     return data;
   }
 

--- a/test/core/codec/leb128/leb128_test.cpp
+++ b/test/core/codec/leb128/leb128_test.cpp
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <gtest/gtest.h>
-
 #include "core/codec/leb128/leb128_codec_tester.hpp"
+
+#include <gtest/gtest.h>
+#include "testutil/outcome.hpp"
 
 using boost::math::tools::max_value;
 using boost::math::tools::min_value;
@@ -64,14 +65,14 @@ TYPED_TEST(LEB128CodecTester, DecodeEmptyVectorFailure) {
 }
 
 /**
- * @given Byte-vector to be decoded, which is greater than decoded value
+ * @given LEB128-encoded value (2^64), next after max value of the uint64_t (2^64 - 1)
  * @when Decoding value with LEB128 codec
  * @then Attempt to decode too big value must be failed
  */
-TYPED_TEST(LEB128CodecTester, DecodeTooBigVectorFailure) {
+TEST(LEB128CodecTest, DecodeSampleOverflowFailure) {
+  std::vector<uint8_t> encoded{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02};
   int expected =
       static_cast<int>(fc::codec::leb128::LEB128DecodeError::INPUT_TOO_BIG);
-  constexpr size_t outsize = (sizeof(TypeParam) + 1) * 2;
-  std::vector<uint8_t> tooBig(outsize);
-  ASSERT_TRUE(this->checkDecodeFail(tooBig, expected));
+  EXPECT_OUTCOME_FALSE_3(result, error_code, fc::codec::leb128::decode<uint64_t>(encoded));
+  ASSERT_EQ(expected, error_code.value());
 }


### PR DESCRIPTION
In previous version decode overflow was detected too late:
uint64_t max value is 2^64-1, it's LEB128 representation is 
`{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}`

Next value is 2^64, which must cause overflow error:
`{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02}`

But overflow for uint64_t was detected only on values, greater than 2^70.

I don't think, that we need separate test for each type (uint8_t, uint16_t ...), because overflow check is common for all data types (uses uint8_t for check execution)