### PR TITLE
Update clang-format column limit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,4 @@ PointerAlignment: Right
 BinPackArguments: false
 BinPackParameters: false
 AllowShortFunctionsOnASingleLine: Empty
+ColumnLimit: 120


### PR DESCRIPTION
### Description of the Change

Increase source code line maximum length to 120 symbols:
80 symbols per line is an archaism, based on IBM 80-column punched cards

### Benefits

Significant increase in code readability

### Possible Drawbacks 

None
