### PR TITLE
change char to uint8_t in filestore

### DIFF
--- a/core/storage/filestore/file.hpp
+++ b/core/storage/filestore/file.hpp
@@ -49,7 +49,7 @@ namespace fc::storage::filestore {
      * @return number of bytes read
      */
     virtual fc::outcome::result<size_t> read(size_t offset,
-                                             const gsl::span<char> &buffer) noexcept = 0;
+                                             const gsl::span<uint8_t> &buffer) noexcept = 0;
 
     /**
      * @brief write to the file
@@ -58,7 +58,7 @@ namespace fc::storage::filestore {
      * @return number of bytes written
      */
     virtual fc::outcome::result<size_t> write(size_t offset,
-                                              const gsl::span<const char> &buffer) noexcept = 0;
+                                              const gsl::span<const uint8_t> &buffer) noexcept = 0;
 
     /**
      * @brief Whether the file is open

--- a/core/storage/filestore/impl/filesystem/filesystem_file.cpp
+++ b/core/storage/filestore/impl/filesystem/filesystem_file.cpp
@@ -51,28 +51,30 @@ fc::outcome::result<void> FileSystemFile::close() noexcept {
 }
 
 fc::outcome::result<size_t> FileSystemFile::read(
-    size_t offset, const gsl::span<char> &buffer) noexcept {
+    size_t offset, const gsl::span<uint8_t> &buffer) noexcept {
   OUTCOME_TRY(file_exists, exists());
   if (!file_exists) return FileStoreError::FILE_NOT_FOUND;
   if (!fstream_.is_open()) return FileStoreError::FILE_CLOSED;
   if (fstream_.fail()) return FileStoreError::UNKNOWN;
 
   fstream_.seekg(offset, std::ios_base::beg);
-  fstream_.read(buffer.data(), buffer.size());
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  fstream_.read(reinterpret_cast<char *>(buffer.data()), buffer.size());
   auto res = fstream_.gcount();
 
   return res;
 }
 
 fc::outcome::result<size_t> FileSystemFile::write(
-    size_t offset, const gsl::span<const char> &buffer) noexcept {
+    size_t offset, const gsl::span<const uint8_t> &buffer) noexcept {
   OUTCOME_TRY(file_exists, exists());
   if (!file_exists) return FileStoreError::FILE_NOT_FOUND;
   if (!fstream_.is_open()) return FileStoreError::FILE_CLOSED;
   if (fstream_.fail()) return FileStoreError::UNKNOWN;
 
   fstream_.seekp(offset, std::ios_base::beg);
-  fstream_.write(buffer.data(), buffer.size());
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  fstream_.write(reinterpret_cast<const char *>(buffer.data()), buffer.size());
   fstream_.flush();
   auto pos = fstream_.tellp();
   if (pos == -1) return FileStoreError::UNKNOWN;

--- a/core/storage/filestore/impl/filesystem/filesystem_file.hpp
+++ b/core/storage/filestore/impl/filesystem/filesystem_file.hpp
@@ -36,11 +36,11 @@ namespace fc::storage::filestore {
 
     /** \copydoc File::read() */
     fc::outcome::result<size_t> read(
-        size_t offset, const gsl::span<char> &buffer) noexcept override;
+        size_t offset, const gsl::span<uint8_t> &buffer) noexcept override;
 
     /** \copydoc File::write() */
     fc::outcome::result<size_t> write(
-        size_t offset, const gsl::span<const char> &buffer) noexcept override;
+        size_t offset, const gsl::span<const uint8_t> &buffer) noexcept override;
 
     /** \copydoc File::is_open() */
     bool is_open() const noexcept override;

--- a/test/core/storage/filestore/filesystem/filesystem_file_test.cpp
+++ b/test/core/storage/filestore/filesystem/filesystem_file_test.cpp
@@ -52,12 +52,12 @@ TEST_F(FileSystemFileTest, FileNotFound) {
   auto res_size = file->size();
   ASSERT_FALSE(res_size);
 
-  std::vector<char> buff{'a', 'b', 'c'};
+  std::vector<uint8_t> buff{'a', 'b', 'c'};
   auto write_res = file->write(0, buff);
   ASSERT_FALSE(write_res);
   ASSERT_EQ(FileStoreError::FILE_NOT_FOUND, write_res.error());
 
-  std::array<char, 3> read_buff{};
+  std::array<uint8_t, 3> read_buff{};
   auto read_res = file->read(0, read_buff);
   ASSERT_FALSE(read_res);
   ASSERT_EQ(FileStoreError::FILE_NOT_FOUND, read_res.error());
@@ -95,12 +95,12 @@ TEST_F(FileSystemFileTest, CloseFile) {
   EXPECT_OUTCOME_TRUE_1(empty_file->close());
   ASSERT_FALSE(empty_file->is_open());
 
-  std::vector<char> buff{'A', 'B', 'C'};
+  std::vector<uint8_t> buff{'A', 'B', 'C'};
   auto write_res = empty_file->write(0, buff);
   ASSERT_FALSE(write_res);
   ASSERT_EQ(FileStoreError::FILE_CLOSED, write_res.error());
 
-  std::array<char, 3> read_buff{};
+  std::array<uint8_t, 3> read_buff{};
   auto read_res = empty_file->read(0, read_buff);
   ASSERT_FALSE(read_res);
   ASSERT_EQ(FileStoreError::FILE_CLOSED, read_res.error());
@@ -122,7 +122,7 @@ TEST_F(FileSystemFileTest, CloseFile) {
 TEST_F(FileSystemFileTest, WriteZeroBytesToFile) {
   EXPECT_OUTCOME_TRUE_1(empty_file->open());
 
-  std::vector<char> buff;
+  std::vector<uint8_t> buff;
   EXPECT_OUTCOME_TRUE(write_res, empty_file->write(0, buff));
   ASSERT_EQ(0, write_res);
 }
@@ -135,7 +135,7 @@ TEST_F(FileSystemFileTest, WriteZeroBytesToFile) {
 TEST_F(FileSystemFileTest, WriteToFile) {
   EXPECT_OUTCOME_TRUE_1(empty_file->open());
 
-  std::vector<char> buff{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
+  std::vector<uint8_t> buff{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
   const size_t buff_size = buff.size();
 
   EXPECT_OUTCOME_TRUE(write_res, empty_file->write(0, buff));
@@ -163,7 +163,7 @@ TEST_F(FileSystemFileTest, WriteAtPos) {
   EXPECT_OUTCOME_TRUE_1(empty_file->open());
 
   size_t start = 12;
-  std::vector<char> data{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
+  std::vector<uint8_t> data{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
   size_t data_size = data.size();
 
   EXPECT_OUTCOME_TRUE(write_res, empty_file->write(start, data));
@@ -175,7 +175,7 @@ TEST_F(FileSystemFileTest, WriteAtPos) {
   auto read_count = check_file.gcount();
 
   // first *start* symbols are 0
-  std::vector<char> zeroes(data_read, data_read + start);
+  std::vector<uint8_t> zeroes(data_read, data_read + start);
   ASSERT_THAT(zeroes, testing::Each(0));
 
   ASSERT_EQ(read_count, start + data_size);
@@ -195,18 +195,18 @@ TEST_F(FileSystemFileTest, OverwriteAtPos) {
   EXPECT_OUTCOME_TRUE_1(empty_file->open());
 
   size_t start = 0;
-  std::vector<char> data{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
+  std::vector<uint8_t> data{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
 
   EXPECT_OUTCOME_TRUE(write_res, empty_file->write(start, data));
   ASSERT_EQ(data.size(), write_res);
 
   start = 6;
-  std::vector<char> more_data{'C', '+', '+', ' ', 'w', 'o', 'r', 'l', 'd'};
+  std::vector<uint8_t> more_data{'C', '+', '+', ' ', 'w', 'o', 'r', 'l', 'd'};
 
   EXPECT_OUTCOME_TRUE(write_res2, empty_file->write(start, more_data));
   ASSERT_EQ(more_data.size(), write_res2);
 
-  std::vector<char> expected{'h',
+  std::vector<uint8_t> expected{'h',
                              'e',
                              'l',
                              'l',
@@ -245,7 +245,7 @@ TEST_F(FileSystemFileTest, OverwriteAtPos) {
 TEST_F(FileSystemFileTest, ReadEmptyFile) {
   EXPECT_OUTCOME_TRUE_1(empty_file->open());
 
-  std::vector<char> data(32);
+  std::vector<uint8_t> data(32);
   EXPECT_OUTCOME_TRUE(read_res, empty_file->read(0, data));
   ASSERT_EQ(0, read_res);
 }
@@ -265,7 +265,7 @@ TEST_F(FileSystemFileTest, ReadFileFrom) {
   size_t read_from = 6;
   size_t read_size = 3;
   char expected[]{'C', '+', '+'};
-  std::vector<char> data_read(read_size);
+  std::vector<uint8_t> data_read(read_size);
   EXPECT_OUTCOME_TRUE(read_res, empty_file->read(read_from, data_read));
   ASSERT_EQ(read_size, read_res);
   ASSERT_TRUE(memcmp(expected, data_read.data(), read_size) == 0);


### PR DESCRIPTION
Signed-off-by: Alexey Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Change char to uint8_t.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Since uint8_t is basic character type for cpp-filecoin project, it will be more suitable to use without reinterpret casting.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
