### PR TITLE
Cbor refactor

### DIFF
--- a/core/codec/cbor/cbor.hpp
+++ b/core/codec/cbor/cbor.hpp
@@ -18,10 +18,14 @@ namespace fc::codec::cbor {
    * @return encoded data
    */
   template <typename T>
-  std::vector<uint8_t> encode(const T &arg) {
-    CborEncodeStream encoder;
-    encoder << arg;
-    return encoder.data();
+  outcome::result<std::vector<uint8_t>> encode(const T &arg) {
+    try {
+      CborEncodeStream encoder;
+      encoder << arg;
+      return encoder.data();
+    } catch (std::system_error &e) {
+      return outcome::failure(e.code());
+    }
   }
 
   /**
@@ -32,7 +36,7 @@ namespace fc::codec::cbor {
    * @see cbor_errors.hpp for possible error cases
    */
   template <typename T>
-  outcome::result<T> decode(const std::vector<uint8_t> &input) {
+  outcome::result<T> decode(gsl::span<const uint8_t> input) {
     try {
       T data;
       CborDecodeStream decoder(input);

--- a/core/codec/cbor/cbor_encode_stream.cpp
+++ b/core/codec/cbor/cbor_encode_stream.cpp
@@ -7,7 +7,7 @@
 
 namespace fc::codec::cbor {
   CborEncodeStream &CborEncodeStream::operator<<(
-      const std::vector<uint8_t> &bytes) {
+      const gsl::span<const uint8_t> &bytes) {
     addCount(1);
 
     std::vector<uint8_t> encoded(9 + bytes.size());
@@ -144,6 +144,14 @@ namespace fc::codec::cbor {
 
   std::map<std::string, CborEncodeStream> CborEncodeStream::map() {
     return {};
+  }
+
+  CborEncodeStream CborEncodeStream::wrap(gsl::span<const uint8_t> data,
+                                          size_t count) {
+    CborEncodeStream s;
+    s.data_.assign(data.begin(), data.end());
+    s.count_ = count;
+    return s;
   }
 
   void CborEncodeStream::addCount(size_t count) {

--- a/core/codec/cbor/cbor_encode_stream.hpp
+++ b/core/codec/cbor/cbor_encode_stream.hpp
@@ -41,7 +41,7 @@ namespace fc::codec::cbor {
     }
 
     /** Encodes bytes */
-    CborEncodeStream &operator<<(const std::vector<uint8_t> &bytes);
+    CborEncodeStream &operator<<(const gsl::span<const uint8_t> &bytes);
     /** Encodes string */
     CborEncodeStream &operator<<(const std::string &str);
     /** Encodes CID */
@@ -59,6 +59,8 @@ namespace fc::codec::cbor {
     static CborEncodeStream list();
     /** Creates map container encode substream map */
     static std::map<std::string, CborEncodeStream> map();
+    /** Wraps CBOR bytes */
+    static CborEncodeStream wrap(gsl::span<const uint8_t> data, size_t count);
 
    private:
     void addCount(size_t count);

--- a/core/primitives/big_int.hpp
+++ b/core/primitives/big_int.hpp
@@ -21,13 +21,12 @@ namespace fc::primitives {
     using cpp_int::cpp_int;
   };
 
-  template <
-      class Stream,
-      class T,
-      typename = std::enable_if_t<
-          (std::is_same_v<T, BigInt> || std::is_same_v<T, UBigInt>)&&Stream::
-              is_cbor_encoder_stream>>
-  Stream &operator<<(Stream &s, const T &big_int) {
+  template <class Stream,
+            class T,
+            typename = std::enable_if_t<
+                (std::is_same_v<T, BigInt> || std::is_same_v<T, UBigInt>)&&std::
+                    remove_reference<Stream>::type::is_cbor_encoder_stream>>
+  Stream &operator<<(Stream &&s, const T &big_int) {
     std::vector<uint8_t> bytes;
     if (big_int != 0) {
       if (std::is_same_v<T, BigInt>) {

--- a/test/testutil/outcome.hpp
+++ b/test/testutil/outcome.hpp
@@ -107,4 +107,10 @@
 #define EXPECT_OUTCOME_ERROR(ecode, expr) \
   EXPECT_OUTCOME_ERROR_3(UNIQUE_NAME(_e), ecode, expr)
 
+#define EXPECT_OUTCOME_EQ_3(var, expr, value) \
+  { EXPECT_OUTCOME_TRUE_2(var, expr); EXPECT_EQ(var, value); }
+
+#define EXPECT_OUTCOME_EQ(expr, value) \
+  EXPECT_OUTCOME_EQ_3(UNIQUE_NAME(_v), expr, value)
+
 #endif  // CPP_FILECOIN_GTEST_OUTCOME_UTIL_HPP


### PR DESCRIPTION
cbor: return outcome from encode, replace vector arg with gsl span, make encoder from bytes.
big_int: rvalue.
cbor_test: kDummyCid, EXPECT_OUTCOME_EQ.
