### PR TITLE
Account actor

### DIFF
--- a/core/vm/actor/CMakeLists.txt
+++ b/core/vm/actor/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 
 add_library(actor
+    account_actor.cpp
     actor.cpp
     init_actor.cpp
     cron_actor.cpp

--- a/core/vm/actor/account_actor.cpp
+++ b/core/vm/actor/account_actor.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "vm/actor/account_actor.hpp"
+
+namespace fc::vm::actor {
+  outcome::result<Address> AccountActor::create(
+      std::shared_ptr<state::StateTree> state_tree, const Address &address) {
+    if (!address.isKeyType()) {
+      return CREATE_WRONG_ADDRESS_TYPE;
+    }
+    Actor actor{kAccountCodeCid, ActorSubstateCID{kEmptyObjectCid}, 0, 0};
+    if (address.getProtocol() == Protocol::BLS) {
+      OUTCOME_TRY(state,
+                  state_tree->store()->setCbor(AccountActorState{address}));
+      actor.head = ActorSubstateCID{state};
+    }
+    return state_tree->registerNewAddress(address, actor);
+  }
+
+  outcome::result<Address> AccountActor::resolveToKeyAddress(
+      std::shared_ptr<state::StateTree> state_tree, const Address &address) {
+    if (address.isKeyType()) {
+      return address;
+    }
+    auto maybe_actor = state_tree->get(address);
+    if (!maybe_actor) {
+      return RESOLVE_NOT_FOUND;
+    }
+    auto actor = maybe_actor.value();
+    if (actor.code != kAccountCodeCid) {
+      return RESOLVE_NOT_ACCOUNT_ACTOR;
+    }
+    OUTCOME_TRY(account_actor_state,
+                state_tree->store()->getCbor<AccountActorState>(actor.head));
+    return account_actor_state.address;
+  }
+}  // namespace fc::vm::actor

--- a/core/vm/actor/account_actor.cpp
+++ b/core/vm/actor/account_actor.cpp
@@ -6,7 +6,7 @@
 #include "vm/actor/account_actor.hpp"
 
 namespace fc::vm::actor {
-  outcome::result<Address> AccountActor::create(
+  outcome::result<Actor> AccountActor::create(
       const std::shared_ptr<StateTree> &state_tree, const Address &address) {
     if (!address.isKeyType()) {
       return CREATE_WRONG_ADDRESS_TYPE;
@@ -14,10 +14,11 @@ namespace fc::vm::actor {
     Actor actor{kAccountCodeCid, ActorSubstateCID{kEmptyObjectCid}, 0, 0};
     if (address.getProtocol() == Protocol::BLS) {
       OUTCOME_TRY(state,
-                  state_tree->store()->setCbor(AccountActorState{address}));
+                  state_tree->getStore()->setCbor(AccountActorState{address}));
       actor.head = ActorSubstateCID{state};
     }
-    return state_tree->registerNewAddress(address, actor);
+    OUTCOME_TRY(state_tree->registerNewAddress(address, actor));
+    return actor;
   }
 
   outcome::result<Address> AccountActor::resolveToKeyAddress(
@@ -34,7 +35,7 @@ namespace fc::vm::actor {
       return RESOLVE_NOT_ACCOUNT_ACTOR;
     }
     OUTCOME_TRY(account_actor_state,
-                state_tree->store()->getCbor<AccountActorState>(actor.head));
+                state_tree->getStore()->getCbor<AccountActorState>(actor.head));
     return account_actor_state.address;
   }
 }  // namespace fc::vm::actor

--- a/core/vm/actor/account_actor.cpp
+++ b/core/vm/actor/account_actor.cpp
@@ -7,7 +7,7 @@
 
 namespace fc::vm::actor {
   outcome::result<Address> AccountActor::create(
-      std::shared_ptr<state::StateTree> state_tree, const Address &address) {
+      const std::shared_ptr<StateTree> &state_tree, const Address &address) {
     if (!address.isKeyType()) {
       return CREATE_WRONG_ADDRESS_TYPE;
     }
@@ -21,7 +21,7 @@ namespace fc::vm::actor {
   }
 
   outcome::result<Address> AccountActor::resolveToKeyAddress(
-      std::shared_ptr<state::StateTree> state_tree, const Address &address) {
+      const std::shared_ptr<StateTree> &state_tree, const Address &address) {
     if (address.isKeyType()) {
       return address;
     }

--- a/core/vm/actor/account_actor.hpp
+++ b/core/vm/actor/account_actor.hpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CPP_FILECOIN_CORE_VM_ACTOR_ACCOUNT_ACTOR_HPP
+#define CPP_FILECOIN_CORE_VM_ACTOR_ACCOUNT_ACTOR_HPP
+
+#include "primitives/address/address_codec.hpp"
+#include "vm/exit_code/exit_code.hpp"
+#include "vm/state/state_tree.hpp"
+
+namespace fc::vm::actor {
+  using primitives::address::Address;
+  using primitives::address::Protocol;
+
+  struct AccountActorState {
+    Address address;
+  };
+
+  template <class Stream,
+            typename = std::enable_if_t<
+                std::remove_reference_t<Stream>::is_cbor_encoder_stream>>
+  Stream &operator<<(Stream &&s, const AccountActorState &state) {
+    return s << (s.list() << state.address);
+  }
+
+  template <class Stream,
+            typename = std::enable_if_t<
+                std::remove_reference_t<Stream>::is_cbor_decoder_stream>>
+  Stream &operator>>(Stream &&s, AccountActorState &state) {
+    s.list() >> state.address;
+    return s;
+  }
+
+  struct AccountActor {
+    static constexpr VMExitCode CREATE_WRONG_ADDRESS_TYPE{1};
+    static constexpr VMExitCode RESOLVE_NOT_FOUND{1};
+    static constexpr VMExitCode RESOLVE_NOT_ACCOUNT_ACTOR{1};
+
+    /// Create account actor from BLS or Secp256k1 address
+    static outcome::result<Address> create(
+        std::shared_ptr<state::StateTree> state_tree, const Address &address);
+    /// Get BLS address of account actor from ID address
+    static outcome::result<Address> resolveToKeyAddress(
+        std::shared_ptr<state::StateTree> state_tree, const Address &address);
+  };
+}  // namespace fc::vm::actor
+
+#endif  // CPP_FILECOIN_CORE_VM_ACTOR_ACCOUNT_ACTOR_HPP

--- a/core/vm/actor/account_actor.hpp
+++ b/core/vm/actor/account_actor.hpp
@@ -34,15 +34,21 @@ namespace fc::vm::actor {
     return s;
   }
 
+  /// Account actors represent actors without code
   struct AccountActor {
     static constexpr VMExitCode CREATE_WRONG_ADDRESS_TYPE{1};
     static constexpr VMExitCode RESOLVE_NOT_FOUND{1};
     static constexpr VMExitCode RESOLVE_NOT_ACCOUNT_ACTOR{1};
 
     /// Create account actor from BLS or Secp256k1 address
-    static outcome::result<Address> create(
+    static outcome::result<Actor> create(
         const std::shared_ptr<StateTree> &state_tree, const Address &address);
-    /// Get BLS address of account actor from ID address
+    /**
+     * Get BLS address of account actor from ID address
+     * @param state_tree state tree
+     * @param address id address to be resolved to key address
+     * @returns key address associated with id address
+     */
     static outcome::result<Address> resolveToKeyAddress(
         const std::shared_ptr<StateTree> &state_tree, const Address &address);
   };

--- a/core/vm/actor/account_actor.hpp
+++ b/core/vm/actor/account_actor.hpp
@@ -13,6 +13,7 @@
 namespace fc::vm::actor {
   using primitives::address::Address;
   using primitives::address::Protocol;
+  using state::StateTree;
 
   struct AccountActorState {
     Address address;
@@ -40,10 +41,10 @@ namespace fc::vm::actor {
 
     /// Create account actor from BLS or Secp256k1 address
     static outcome::result<Address> create(
-        std::shared_ptr<state::StateTree> state_tree, const Address &address);
+        const std::shared_ptr<StateTree> &state_tree, const Address &address);
     /// Get BLS address of account actor from ID address
     static outcome::result<Address> resolveToKeyAddress(
-        std::shared_ptr<state::StateTree> state_tree, const Address &address);
+        const std::shared_ptr<StateTree> &state_tree, const Address &address);
   };
 }  // namespace fc::vm::actor
 

--- a/core/vm/state/state_tree.cpp
+++ b/core/vm/state/state_tree.cpp
@@ -67,4 +67,8 @@ namespace fc::vm::state {
     hamt_ = snapshot_;
     return outcome::success();
   }
+
+  std::shared_ptr<IpfsDatastore> StateTree::store() {
+    return store_;
+  }
 }  // namespace fc::vm::state

--- a/core/vm/state/state_tree.cpp
+++ b/core/vm/state/state_tree.cpp
@@ -68,7 +68,7 @@ namespace fc::vm::state {
     return outcome::success();
   }
 
-  std::shared_ptr<IpfsDatastore> StateTree::store() {
+  std::shared_ptr<IpfsDatastore> StateTree::getStore() {
     return store_;
   }
 }  // namespace fc::vm::state

--- a/core/vm/state/state_tree.hpp
+++ b/core/vm/state/state_tree.hpp
@@ -34,7 +34,7 @@ namespace fc::vm::state {
     /// Revert changes to last flushed state
     outcome::result<void> revert();
     /// Get store
-    std::shared_ptr<IpfsDatastore> store();
+    std::shared_ptr<IpfsDatastore> getStore();
 
    private:
     std::shared_ptr<IpfsDatastore> store_;

--- a/core/vm/state/state_tree.hpp
+++ b/core/vm/state/state_tree.hpp
@@ -19,8 +19,7 @@ namespace fc::vm::state {
   class StateTree {
    public:
     explicit StateTree(const std::shared_ptr<IpfsDatastore> &store);
-    StateTree(const std::shared_ptr<IpfsDatastore> &store,
-              const CID &root);
+    StateTree(const std::shared_ptr<IpfsDatastore> &store, const CID &root);
     /// Set actor state, does not write to storage
     outcome::result<void> set(const Address &address, const Actor &actor);
     /// Get actor state
@@ -34,6 +33,8 @@ namespace fc::vm::state {
     outcome::result<CID> flush();
     /// Revert changes to last flushed state
     outcome::result<void> revert();
+    /// Get store
+    std::shared_ptr<IpfsDatastore> store();
 
    private:
     std::shared_ptr<IpfsDatastore> store_;

--- a/test/core/vm/actor/CMakeLists.txt
+++ b/test/core/vm/actor/CMakeLists.txt
@@ -34,3 +34,12 @@ addtest(invoker_test
 target_link_libraries(invoker_test
         actor
         )
+
+addtest(account_actor_test
+    account_actor_test.cpp
+    )
+target_link_libraries(account_actor_test
+    actor
+    state_tree
+    ipfs_datastore_in_memory
+    )

--- a/test/core/vm/actor/account_actor_test.cpp
+++ b/test/core/vm/actor/account_actor_test.cpp
@@ -25,7 +25,7 @@ TEST(AccountActorTest, AccountActorStateCbor) {
  * @then Returned BLS address is equal to original
  */
 TEST(InitActorTest, CreateResolve) {
-  auto state_tree = setupInitActor(nullptr, 0);
+  auto state_tree = setupInitActor(nullptr);
   auto addr1 = Address::makeFromId(3);
   Address addr2{
       fc::primitives::address::Network::TESTNET,
@@ -47,7 +47,9 @@ TEST(InitActorTest, CreateResolve) {
                        AccountActor::resolveToKeyAddress(state_tree, addr1));
 
   actor.code = fc::vm::actor::kAccountCodeCid;
-  EXPECT_OUTCOME_TRUE(addr2_id, AccountActor::create(state_tree, addr2));
+  EXPECT_OUTCOME_TRUE(actor2, AccountActor::create(state_tree, addr2));
+  EXPECT_EQ(actor2.code, fc::vm::actor::kAccountCodeCid);
+  EXPECT_OUTCOME_TRUE(addr2_id, state_tree->lookupId(addr2));
   EXPECT_OUTCOME_EQ(AccountActor::resolveToKeyAddress(state_tree, addr2_id),
                     addr2);
 }

--- a/test/core/vm/actor/account_actor_test.cpp
+++ b/test/core/vm/actor/account_actor_test.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "vm/actor/account_actor.hpp"
+
+#include "testutil/init_actor.hpp"
+
+using fc::primitives::address::Address;
+using fc::vm::actor::AccountActor;
+using fc::vm::actor::AccountActorState;
+using fc::vm::state::StateTree;
+
+/// Account actor state CBOR encoding and decoding
+TEST(AccountActorTest, AccountActorStateCbor) {
+  AccountActorState state{Address::makeFromId(3)};
+  expectEncodeAndReencode(state, "81420003"_unhex);
+}
+
+/**
+ * @given Empty state tree and actor
+ * @when Create account actor with BLS address @and resolve BLS address from
+ * assigned ID address
+ * @then Returned BLS address is equal to original
+ */
+TEST(InitActorTest, CreateResolve) {
+  auto state_tree = setupInitActor(nullptr, 0);
+  auto addr1 = Address::makeFromId(3);
+  Address addr2{
+      fc::primitives::address::Network::TESTNET,
+      fc::primitives::address::BLSPublicKeyHash{
+          "010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101"_blob48}};
+  fc::vm::actor::Actor actor{
+      fc::vm::actor::kCronCodeCid,
+      fc::vm::actor::ActorSubstateCID{"010001020002"_cid},
+      0,
+      0};
+
+  EXPECT_OUTCOME_ERROR(AccountActor::CREATE_WRONG_ADDRESS_TYPE,
+                       AccountActor::create(state_tree, addr1));
+
+  EXPECT_OUTCOME_ERROR(AccountActor::RESOLVE_NOT_FOUND,
+                       AccountActor::resolveToKeyAddress(state_tree, addr1));
+  EXPECT_OUTCOME_TRUE_1(state_tree->set(addr1, actor));
+  EXPECT_OUTCOME_ERROR(AccountActor::RESOLVE_NOT_ACCOUNT_ACTOR,
+                       AccountActor::resolveToKeyAddress(state_tree, addr1));
+
+  actor.code = fc::vm::actor::kAccountCodeCid;
+  EXPECT_OUTCOME_TRUE(addr2_id, AccountActor::create(state_tree, addr2));
+  EXPECT_OUTCOME_EQ(AccountActor::resolveToKeyAddress(state_tree, addr2_id),
+                    addr2);
+}

--- a/test/core/vm/state/state_tree_test.cpp
+++ b/test/core/vm/state/state_tree_test.cpp
@@ -7,10 +7,7 @@
 
 #include <gtest/gtest.h>
 #include "primitives/address/address_codec.hpp"
-#include "storage/hamt/hamt.hpp"
-#include "storage/ipfs/impl/in_memory_datastore.hpp"
-#include "testutil/cbor.hpp"
-#include "vm/actor/init_actor.hpp"
+#include "testutil/init_actor.hpp"
 
 using fc::primitives::BigInt;
 using fc::primitives::address::Address;
@@ -74,20 +71,11 @@ TEST_F(StateTreeTest, SetRevert) {
  * @then Actor state in the tree is same
  */
 TEST_F(StateTreeTest, RegisterNewAddressLookupId) {
-  using fc::vm::actor::InitActorState;
-  using fc::vm::actor::kInitAddress;
-  EXPECT_OUTCOME_TRUE(empty_map, Hamt(store_).flush());
-  InitActorState init_actor_state{empty_map, 13};
-  EXPECT_OUTCOME_TRUE(init_actor_state_cid, store_->setCbor(init_actor_state));
-  Actor init_actor{CodeId{"010001020000"_cid},
-                   ActorSubstateCID{init_actor_state_cid},
-                   {},
-                   {}};
-  EXPECT_OUTCOME_TRUE_1(tree_.set(kInitAddress, init_actor));
+  auto tree = setupInitActor(nullptr, 13);
   Address address{fc::primitives::address::TESTNET,
                   fc::primitives::address::ActorExecHash{}};
-  EXPECT_OUTCOME_EQ(tree_.registerNewAddress(address, kActor), kAddressId);
-  EXPECT_OUTCOME_EQ(tree_.lookupId(address), kAddressId);
-  EXPECT_OUTCOME_EQ(tree_.get(address), kActor);
-  EXPECT_OUTCOME_EQ(tree_.get(kAddressId), kActor);
+  EXPECT_OUTCOME_EQ(tree->registerNewAddress(address, kActor), kAddressId);
+  EXPECT_OUTCOME_EQ(tree->lookupId(address), kAddressId);
+  EXPECT_OUTCOME_EQ(tree->get(address), kActor);
+  EXPECT_OUTCOME_EQ(tree->get(kAddressId), kActor);
 }

--- a/test/testutil/init_actor.hpp
+++ b/test/testutil/init_actor.hpp
@@ -1,0 +1,28 @@
+#ifndef CPP_FILECOIN_TEST_TESTUTIL_INIT_ACTOR_HPP
+#define CPP_FILECOIN_TEST_TESTUTIL_INIT_ACTOR_HPP
+
+#include <gtest/gtest.h>
+#include "storage/ipfs/impl/in_memory_datastore.hpp"
+#include "testutil/cbor.hpp"
+#include "vm/actor/init_actor.hpp"
+#include "vm/state/state_tree.hpp"
+
+std::shared_ptr<fc::vm::state::StateTree> setupInitActor(
+    std::shared_ptr<fc::vm::state::StateTree> state_tree, uint64_t next_id) {
+  if (!state_tree) {
+    state_tree = std::make_shared<fc::vm::state::StateTree>(
+        std::make_shared<fc::storage::ipfs::InMemoryDatastore>());
+  }
+  auto store = state_tree->store();
+  EXPECT_OUTCOME_TRUE(empty_map, fc::storage::hamt::Hamt(store).flush());
+  EXPECT_OUTCOME_TRUE(
+      state, store->setCbor(fc::vm::actor::InitActorState{empty_map, next_id}));
+  EXPECT_OUTCOME_TRUE_1(state_tree->set(fc::vm::actor::kInitAddress,
+                                        {fc::vm::actor::kInitCodeCid,
+                                         fc::vm::actor::ActorSubstateCID{state},
+                                         0,
+                                         0}));
+  return state_tree;
+}
+
+#endif  // CPP_FILECOIN_TEST_TESTUTIL_INIT_ACTOR_HPP

--- a/test/testutil/init_actor.hpp
+++ b/test/testutil/init_actor.hpp
@@ -7,13 +7,15 @@
 #include "vm/actor/init_actor.hpp"
 #include "vm/state/state_tree.hpp"
 
+/// Sets up init actor state
 std::shared_ptr<fc::vm::state::StateTree> setupInitActor(
-    std::shared_ptr<fc::vm::state::StateTree> state_tree, uint64_t next_id) {
+    std::shared_ptr<fc::vm::state::StateTree> state_tree,
+    uint64_t next_id = 100) {
   if (!state_tree) {
     state_tree = std::make_shared<fc::vm::state::StateTree>(
         std::make_shared<fc::storage::ipfs::InMemoryDatastore>());
   }
-  auto store = state_tree->store();
+  auto store = state_tree->getStore();
   EXPECT_OUTCOME_TRUE(empty_map, fc::storage::hamt::Hamt(store).flush());
   EXPECT_OUTCOME_TRUE(
       state, store->setCbor(fc::vm::actor::InitActorState{empty_map, next_id}));


### PR DESCRIPTION
### Description of the Change
Add `AccountActorState` and CBOR encode/decode.
Add `AccountActor::create`, `AccountActor::resolveToKeyAddress`.
Add `StateTree.store`.
Add `setupInitActor` to testutil.

### Benefits
Account actor

### Possible Drawbacks 
None