### PR TITLE
IPFS MerkleDAG service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,12 @@ jobs:
           brew install ninja
         else
           sudo apt-get update || true
-          sudo apt-get install -y ninja-build
+          sudo apt-get install -y ninja-build python-setuptools
         fi
 
         pip3 -V || sudo python3 -m pip install --upgrade pip
-        sudo pip3 install scikit-build cmake requests gitpython gcovr pyyaml
+        sudo pip3 install scikit-build
+        sudo pip3 install cmake requests gitpython gcovr pyyaml
         sudo curl https://sh.rustup.rs -sSf | sh -s -- -y
     - name: cmake
       env:

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -30,7 +30,7 @@ hunter_config(
 )
 
 hunter_config(libp2p
-    URL https://github.com/soramitsu/libp2p/archive/cdc092fe74ef5d8eeedf42e3e949488ff5052cb4.zip
-    SHA1 16605084e4f018ebdb09018e906a54aa1909c8e1
+    URL https://github.com/soramitsu/libp2p/archive/06a70dfcdc2649264f44c460a542e0c774db2290.zip
+    SHA1 c6bbd0e55659fb0a7a84091a97d219f59ae37d14
     CMAKE_ARGS TESTING=OFF
     )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -45,3 +45,7 @@ find_package(libp2p CONFIG REQUIRED)
 # https://docs.hunter.sh/en/latest/packages/pkg/cppcodec.html
 hunter_add_package(cppcodec)
 find_package(cppcodec CONFIG REQUIRED)
+
+# https://hunter.readthedocs.io/en/stable/packages/pkg/Protobuf.html
+hunter_add_package(Protobuf)
+find_package(Protobuf CONFIG REQUIRED)

--- a/core/storage/ipfs/CMakeLists.txt
+++ b/core/storage/ipfs/CMakeLists.txt
@@ -29,3 +29,5 @@ add_library(ipfs_blockservice
 target_link_libraries(ipfs_blockservice
     buffer
     )
+
+add_subdirectory(merkledag)

--- a/core/storage/ipfs/block.hpp
+++ b/core/storage/ipfs/block.hpp
@@ -6,7 +6,10 @@
 #ifndef FILECOIN_STORAGE_IPFS_BLOCK_HPP
 #define FILECOIN_STORAGE_IPFS_BLOCK_HPP
 
+#include <functional>
+
 #include "common/buffer.hpp"
+#include "common/outcome.hpp"
 #include "primitives/cid/cid.hpp"
 
 namespace fc::storage::ipfs {
@@ -31,7 +34,7 @@ namespace fc::storage::ipfs {
      * @brief Get block content
      * @return Block's raw data for store in the BlockService
      */
-    virtual const Content &getContent() const = 0;
+    virtual const Content &getRawBytes() const = 0;
   };
 }  // namespace fc::storage::ipfs
 

--- a/core/storage/ipfs/impl/blockservice_impl.cpp
+++ b/core/storage/ipfs/impl/blockservice_impl.cpp
@@ -15,7 +15,7 @@ namespace fc::storage::ipfs {
   }
 
   outcome::result<void> BlockServiceImpl::addBlock(const Block &block) {
-    auto result = local_storage_->set(block.getCID(), block.getContent());
+    auto result = local_storage_->set(block.getCID(), block.getRawBytes());
     if (result.has_error()) {
       return BlockServiceError::ADD_BLOCK_FAILED;
     }

--- a/core/storage/ipfs/merkledag/CMakeLists.txt
+++ b/core/storage/ipfs/merkledag/CMakeLists.txt
@@ -1,0 +1,34 @@
+find_package(Protobuf REQUIRED)
+set(PB_SCHEME "merkledag.proto")
+set(PB_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+execute_process(COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --cpp_out=${PB_BUILD_DIR} ${PB_SCHEME}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/impl/protobuf
+    RESULT_VARIABLE CMD_OUTPUT
+    )
+
+add_library(ipfs_merkledag_service_protobuf
+    ${PB_BUILD_DIR}/merkledag.pb.h
+    ${PB_BUILD_DIR}/merkledag.pb.cc
+    )
+target_include_directories(ipfs_merkledag_service_protobuf PUBLIC ${PB_BUILD_DIR})
+target_link_libraries(ipfs_merkledag_service_protobuf
+    protobuf::libprotobuf
+    )
+disable_clang_tidy(ipfs_merkledag_service_protobuf)
+
+add_library(ipfs_merkledag_service
+    impl/link_impl.cpp
+    impl/node_impl.cpp
+    impl/merkledag_service_impl.cpp
+    impl/pb_node_encoder.cpp
+    impl/pb_node_decoder.cpp
+    impl/leaf_impl.cpp
+    )
+target_link_libraries(ipfs_merkledag_service
+    cid
+    Boost::boost
+    ipfs_blockservice
+    ipfs_datastore_in_memory
+    ipfs_merkledag_service_protobuf
+    )

--- a/core/storage/ipfs/merkledag/impl/leaf_impl.cpp
+++ b/core/storage/ipfs/merkledag/impl/leaf_impl.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/leaf_impl.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  LeafImpl::LeafImpl(common::Buffer data)
+      : content_{std::move(data)} {}
+
+  const common::Buffer &LeafImpl::content() const {
+    return content_;
+  }
+
+  size_t LeafImpl::count() const {
+    return children_.size();
+  }
+
+  outcome::result<std::reference_wrapper<const Leaf>> LeafImpl::subLeaf(
+      std::string_view name) const {
+    if (auto iter = children_.find(name); iter != children_.end()) {
+      return iter->second;
+    }
+    return LeafError::LEAF_NOT_FOUND;
+  }
+
+  std::vector<std::string_view> LeafImpl::getSubLeafNames() const {
+    std::vector<std::string_view> names;
+    for (const auto &child : children_) {
+      names.push_back(child.first);
+    }
+    return names;
+  }
+
+  outcome::result<void> LeafImpl::insertSubLeaf(std::string name,
+                                                 LeafImpl children) {
+    auto result = children_.emplace(std::move(name), std::move(children));
+    if (result.second) {
+      return outcome::success();
+    }
+    return LeafError::DUPLICATE_LEAF;
+  }
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_CPP_DEFINE_CATEGORY(fc::storage::ipfs::merkledag, LeafError, e) {
+  using fc::storage::ipfs::merkledag::LeafError;
+  switch (e) {
+    case (LeafError::LEAF_NOT_FOUND):
+      return "MerkleDAG leaf: children leaf not found";
+    case (LeafError::DUPLICATE_LEAF):
+      return "MerkleDAG leaf: duplicate leaf name";
+  }
+  return "MerkleDAG leaf: unknown error";
+}

--- a/core/storage/ipfs/merkledag/impl/leaf_impl.hpp
+++ b/core/storage/ipfs/merkledag/impl/leaf_impl.hpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_LEAF_IMPL_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_LEAF_IMPL_HPP
+
+#include "storage/ipfs/merkledag/leaf.hpp"
+
+#include <map>
+#include <string>
+
+namespace fc::storage::ipfs::merkledag {
+  class LeafImpl : public Leaf {
+   public:
+    /**
+     * @brief Construct leaf
+     * @param data - leaf content
+     */
+    explicit LeafImpl(common::Buffer data);
+
+    const common::Buffer &content() const override;
+
+    size_t count() const override;
+
+    outcome::result<std::reference_wrapper<const Leaf>> subLeaf(
+        std::string_view name) const override;
+
+    std::vector<std::string_view> getSubLeafNames() const override;
+
+    /**
+     * @brief Insert children leaf
+     * @param name - id of the leaf
+     * @param children - leaf to insert
+     * @return operation result
+     */
+    outcome::result<void> insertSubLeaf(std::string name, LeafImpl children);
+
+   private:
+    common::Buffer content_;
+    std::map<std::string, LeafImpl, std::less<>> children_;
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+#endif

--- a/core/storage/ipfs/merkledag/impl/link_impl.cpp
+++ b/core/storage/ipfs/merkledag/impl/link_impl.cpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/link_impl.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  LinkImpl::LinkImpl(libp2p::multi::ContentIdentifier id,
+                     std::string name,
+                     size_t size)
+      : cid_{std::move(id)},
+        name_{std::move(name)},
+        size_{size} {}
+
+  const std::string &LinkImpl::getName() const {
+    return name_;
+  }
+
+  const CID &LinkImpl::getCID() const {
+    return cid_;
+  }
+
+  size_t LinkImpl::getSize() const {
+    return size_;
+  }
+}  // namespace fc::storage::ipfs::merkledag

--- a/core/storage/ipfs/merkledag/impl/link_impl.hpp
+++ b/core/storage/ipfs/merkledag/impl/link_impl.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_LINK_IMPL_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_LINK_IMPL_HPP
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "storage/ipfs/merkledag/link.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  class LinkImpl : public Link {
+   public:
+    /**
+     * @brief Construct Link
+     * @param id - CID of the target object
+     * @param name - name of the target object
+     * @param size - total size of the target object
+     */
+    LinkImpl(libp2p::multi::ContentIdentifier id,
+             std::string name,
+             size_t size);
+
+    LinkImpl() = default;
+
+    const std::string &getName() const override;
+
+    const CID &getCID() const override;
+
+    size_t getSize() const override;
+
+   private:
+    CID cid_;
+    std::string name_;
+    size_t size_{};
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+#endif

--- a/core/storage/ipfs/merkledag/impl/merkledag_service_impl.cpp
+++ b/core/storage/ipfs/merkledag/impl/merkledag_service_impl.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/merkledag_service_impl.hpp"
+
+#include <boost/assert.hpp>
+#include "storage/ipfs/merkledag/impl/node_impl.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  MerkleDagServiceImpl::MerkleDagServiceImpl(std::shared_ptr<BlockService> service)
+      : block_service_{std::move(service)} {
+    BOOST_ASSERT_MSG(block_service_ != nullptr,
+                     "MerkleDAG service: Block service not connected");
+  }
+
+  outcome::result<void> MerkleDagServiceImpl::addNode(std::shared_ptr<const Node> node) {
+    return block_service_->addBlock(*node);
+  }
+
+  outcome::result<std::shared_ptr<Node>> MerkleDagServiceImpl::getNode(
+      const CID &cid) const {
+    OUTCOME_TRY(content, block_service_->getBlockContent(cid));
+    return NodeImpl::createFromRawBytes(content);
+  }
+
+  outcome::result<void> MerkleDagServiceImpl::removeNode(const CID &cid) {
+    return block_service_->removeBlock(cid);
+  }
+
+  outcome::result<std::shared_ptr<Leaf>> MerkleDagServiceImpl::fetchGraph(
+      const CID &cid) const {
+    OUTCOME_TRY(node, getNode(cid));
+    auto root_leaf = std::make_shared<LeafImpl>(node->content());
+    auto result = buildGraph(root_leaf, node->getLinks(), false, 0, 0);
+    if (result.has_error()) return result.error();
+    return root_leaf;
+  }
+
+  outcome::result<std::shared_ptr<Leaf>> MerkleDagServiceImpl::fetchGraphOnDepth(
+      const CID &cid, uint64_t depth) const {
+    OUTCOME_TRY(node, getNode(cid));
+    auto leaf = std::make_shared<LeafImpl>(node->content());
+    auto result = buildGraph(leaf, node->getLinks(), true, depth, 0);
+    if (result.has_error()) return result.error();
+    return leaf;
+  }
+
+  outcome::result<void> MerkleDagServiceImpl::buildGraph(
+      const std::shared_ptr<LeafImpl> &root,
+      const std::vector<std::reference_wrapper<const Link>> &links,
+      bool depth_limit,
+      const size_t max_depth,
+      size_t current_depth) const {
+    if (depth_limit && current_depth == max_depth) {
+      return outcome::success();
+    }
+    for (const auto &link : links) {
+      auto request = getNode(link.get().getCID());
+      if (request.has_error()) return ServiceError::UNRESOLVED_LINK;
+      std::shared_ptr<Node> node = request.value();
+      auto child_leaf = std::make_shared<LeafImpl>(node->content());
+      auto build_result = buildGraph(child_leaf,
+                                     node->getLinks(),
+                                     depth_limit,
+                                     max_depth,
+                                     ++current_depth);
+      if (build_result.has_error()) {
+        return build_result;
+      }
+      auto insert_result =
+          root->insertSubLeaf(link.get().getName(), std::move(*child_leaf));
+      if (insert_result.has_error()) {
+        return insert_result;
+      }
+    }
+    return outcome::success();
+  }
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_CPP_DEFINE_CATEGORY(fc::storage::ipfs::merkledag, ServiceError, e) {
+  using fc::storage::ipfs::merkledag::ServiceError;
+  switch (e) {
+    case (ServiceError::UNRESOLVED_LINK):
+      return "MerkleDAG service: broken link";
+  }
+  return "MerkleDAG Node: unknown error";
+}

--- a/core/storage/ipfs/merkledag/impl/merkledag_service_impl.hpp
+++ b/core/storage/ipfs/merkledag/impl/merkledag_service_impl.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_SERVICE_IMPL_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_SERVICE_IMPL_HPP
+
+#include <memory>
+
+#include "storage/ipfs/blockservice.hpp"
+#include "storage/ipfs/merkledag/impl/leaf_impl.hpp"
+#include "storage/ipfs/merkledag/merkledag_service.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  class MerkleDagServiceImpl : public MerkleDagService {
+   public:
+    /**
+     * @brief Construct service
+     * @param service - underlying block service
+     */
+    explicit MerkleDagServiceImpl(std::shared_ptr<BlockService> service);
+
+    outcome::result<void> addNode(std::shared_ptr<const Node> node) override;
+
+    outcome::result<std::shared_ptr<Node>> getNode(
+        const CID &cid) const override;
+
+    outcome::result<void> removeNode(const CID &cid) override;
+
+    outcome::result<std::shared_ptr<Leaf>> fetchGraph(
+        const CID &cid) const override;
+
+    outcome::result<std::shared_ptr<Leaf>> fetchGraphOnDepth(
+        const CID &cid, uint64_t depth) const override;
+
+   private:
+    std::shared_ptr<BlockService> block_service_;
+
+    /**
+     * @brief Fetch graph internal recursive implementation
+     * @param root - leaf, for which we should extract child nodes
+     * @param links - links to the child nodes of this leaf
+     * @param depth_limit - status of the depth control
+     * @param max_depth - e.g. "1" means "Fetch only root node with all
+     * children, but without children of their children"
+     * @param current_depth - value of the depth during current operation
+     * @return operation result
+     */
+    outcome::result<void> buildGraph(
+        const std::shared_ptr<LeafImpl> &root,
+        const std::vector<std::reference_wrapper<const Link>> &links,
+        bool depth_limit,
+        size_t max_depth,
+        size_t current_depth = 0) const;
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+#endif

--- a/core/storage/ipfs/merkledag/impl/node_impl.cpp
+++ b/core/storage/ipfs/merkledag/impl/node_impl.cpp
@@ -1,0 +1,133 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/node_impl.hpp"
+
+#include <libp2p/crypto/sha/sha256.hpp>
+#include <libp2p/multi/content_identifier_codec.hpp>
+#include <libp2p/multi/multibase_codec/codecs/base58.hpp>
+#include <libp2p/multi/multihash.hpp>
+#include "merkledag.pb.h"
+#include "storage/ipfs/merkledag/impl/pb_node_decoder.hpp"
+
+using libp2p::common::Hash256;
+using libp2p::multi::ContentIdentifierCodec;
+using libp2p::multi::HashType;
+using libp2p::multi::MulticodecType;
+using libp2p::multi::Multihash;
+using merkledag::pb::PBLink;
+using merkledag::pb::PBNode;
+using Version = libp2p::multi::ContentIdentifier::Version;
+
+namespace fc::storage::ipfs::merkledag {
+
+  size_t NodeImpl::size() const {
+    return getCachePB().size() + child_nodes_size_;
+  }
+
+  void NodeImpl::assign(common::Buffer input) {
+    content_ = std::move(input);
+    pb_cache_ = boost::none;
+  }
+
+  const common::Buffer &NodeImpl::content() const {
+    return content_;
+  }
+
+  outcome::result<void> NodeImpl::addChild(const std::string &name,
+                                           std::shared_ptr<const Node> node) {
+    LinkImpl link{node->getCID(), name, node->size()};
+    links_.emplace(name, std::move(link));
+    pb_cache_ = boost::none;
+    child_nodes_size_ += node->size();
+    return outcome::success();
+  }
+
+  outcome::result<std::reference_wrapper<const Link>> NodeImpl::getLink(
+      const std::string &name) const {
+    if (auto index = links_.find(name); index != links_.end()) {
+      return index->second;
+    }
+    return NodeError::LINK_NOT_FOUND;
+  }
+
+  void NodeImpl::removeLink(const std::string &link_name) {
+    if (auto index = links_.find(link_name); index != links_.end()) {
+      child_nodes_size_ -= index->second.getSize();
+      links_.erase(index);
+    }
+  }
+
+  const CID &NodeImpl::getCID() const {
+    if (!cid_) {
+      Hash256 digest = libp2p::crypto::sha256(getCachePB().toVector());
+      auto multi_hash = Multihash::create(HashType::sha256, digest);
+      CID id{
+          Version::V0, MulticodecType::DAG_PB, std::move(multi_hash.value())};
+      cid_ = std::move(id);
+    }
+    return cid_.value();
+  }
+
+  const common::Buffer &NodeImpl::getRawBytes() const {
+    return getCachePB();
+  }
+
+  void NodeImpl::addLink(const Link &link) {
+    auto &link_impl = dynamic_cast<const LinkImpl &>(link);
+    links_.emplace(link.getName(), link_impl);
+  }
+
+  std::vector<std::reference_wrapper<const Link>> NodeImpl::getLinks() const {
+    std::vector<std::reference_wrapper<const Link>> link_refs{};
+    for (const auto &link : links_) {
+      link_refs.emplace_back(link.second);
+    }
+    return link_refs;
+  }
+
+  std::shared_ptr<Node> NodeImpl::createFromString(const std::string &content) {
+    std::vector<uint8_t> data{content.begin(), content.end()};
+    auto node = std::make_shared<NodeImpl>();
+    node->assign(common::Buffer{data});
+    return node;
+  }
+
+  outcome::result<std::shared_ptr<Node>> NodeImpl::createFromRawBytes(
+      gsl::span<const uint8_t> input) {
+    PBNodeDecoder decoder;
+    if (auto result = decoder.decode(input); result.has_error()) {
+      return result.error();
+    }
+    auto node = createFromString(decoder.getContent());
+    for (size_t i = 0; i < decoder.getLinksCount(); ++i) {
+      std::vector<uint8_t> link_cid_bytes{decoder.getLinkCID(i).begin(),
+                                          decoder.getLinkCID(i).end()};
+      OUTCOME_TRY(link_cid, ContentIdentifierCodec::decode(link_cid_bytes));
+      LinkImpl link{
+          std::move(link_cid), decoder.getLinkName(i), decoder.getLinkSize(i)};
+      node->addLink(link);
+    }
+    return node;
+  }
+
+  const common::Buffer &NodeImpl::getCachePB() const {
+    if (!pb_cache_) {
+      pb_cache_ = PBNodeEncoder::encode(content_, links_);
+    }
+    return pb_cache_.value();
+  }
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_CPP_DEFINE_CATEGORY(fc::storage::ipfs::merkledag, NodeError, e) {
+  using fc::storage::ipfs::merkledag::NodeError;
+  switch (e) {
+    case (NodeError::LINK_NOT_FOUND):
+      return "MerkleDAG Node: link not exist";
+    case (NodeError::INVALID_RAW_DATA):
+      return "MerkleDAG Node: failed to deserialize from incorrect raw bytes";
+  }
+  return "MerkleDAG Node: unknown error";
+}

--- a/core/storage/ipfs/merkledag/impl/node_impl.hpp
+++ b/core/storage/ipfs/merkledag/impl/node_impl.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_NODE_IMPL_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_NODE_IMPL_HPP
+
+#include <map>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include <boost/optional.hpp>
+#include "primitives/cid/cid.hpp"
+#include "storage/ipfs/merkledag/impl/link_impl.hpp"
+#include "storage/ipfs/merkledag/impl/pb_node_encoder.hpp"
+#include "storage/ipfs/merkledag/node.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  class NodeImpl : public Node {
+   public:
+
+    size_t size() const override;
+
+    void assign(common::Buffer input) override;
+
+    const common::Buffer &content() const override;
+
+    outcome::result<void> addChild(const std::string &name,
+                                   std::shared_ptr<const Node> node) override;
+
+    outcome::result<std::reference_wrapper<const Link>> getLink(
+        const std::string &name) const override;
+
+    void removeLink(const std::string &name) override;
+
+    const CID &getCID() const override;
+
+    const common::Buffer &getRawBytes() const override;
+
+    void addLink(const Link &link) override;
+
+    std::vector<std::reference_wrapper<const Link>> getLinks() const override;
+
+    static std::shared_ptr<Node> createFromString(const std::string &content);
+
+    static outcome::result<std::shared_ptr<Node>> createFromRawBytes(
+        gsl::span<const uint8_t> input);
+
+   private:
+    mutable boost::optional<CID> cid_{};
+    common::Buffer content_;
+    std::map<std::string, LinkImpl> links_;
+    PBNodeEncoder pb_node_codec_;
+    size_t child_nodes_size_{};
+    mutable boost::optional<common::Buffer> pb_cache_{boost::none};
+
+    /**
+     * @brief Check Protobuf-data cache status and generate new if needed
+     * @return Actual protobuf-cache
+     */
+    const common::Buffer &getCachePB() const;
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+#endif

--- a/core/storage/ipfs/merkledag/impl/pb_node_decoder.cpp
+++ b/core/storage/ipfs/merkledag/impl/pb_node_decoder.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/pb_node_decoder.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  outcome::result<void> PBNodeDecoder::decode(gsl::span<const uint8_t> input) {
+    const uint8_t *raw_bytes = input.data();
+    if (pb_node_.ParseFromArray(raw_bytes, input.size())) {
+      return outcome::success();
+    }
+    return PBNodeDecodeError::INVALID_RAW_BYTES;
+  }
+
+  const std::string &PBNodeDecoder::getContent() const {
+    return pb_node_.data();
+  }
+
+  size_t PBNodeDecoder::getLinksCount() const {
+    return pb_node_.links_size();
+  }
+
+  const std::string &PBNodeDecoder::getLinkName(size_t index) const {
+    return pb_node_.links(index).name();
+  }
+
+  const std::string &PBNodeDecoder::getLinkCID(size_t index) const {
+    return pb_node_.links(index).hash();
+  }
+
+  size_t PBNodeDecoder::getLinkSize(size_t index) const {
+    int size = pb_node_.links(index).tsize();
+    return size < 0 ? 0 : static_cast<size_t>(size);
+  }
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_CPP_DEFINE_CATEGORY(fc::storage::ipfs::merkledag,
+                            PBNodeDecodeError,
+                            error) {
+  using fc::storage::ipfs::merkledag::PBNodeDecodeError;
+  switch (error) {
+    case (PBNodeDecodeError::INVALID_RAW_BYTES):
+      return "IPLD node Protobuf decoder: failed to deserialize from incorrect "
+             "raw bytes";
+  }
+  return "IPLD node protobuf decoder: unknown error";
+}

--- a/core/storage/ipfs/merkledag/impl/pb_node_decoder.hpp
+++ b/core/storage/ipfs/merkledag/impl/pb_node_decoder.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_PB_NODE_DECODER
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_PB_NODE_DECODER
+
+#include <string>
+
+#include <gsl/span>
+#include "common/buffer.hpp"
+#include "common/outcome.hpp"
+#include "merkledag.pb.h"
+
+namespace fc::storage::ipfs::merkledag {
+  /**
+   * @class Protobuf Node decoder
+   */
+  class PBNodeDecoder {
+   public:
+    /**
+     * @brief Try to decode input bytes as Protobuf-encoded Node
+     * @param input - bytes to decode
+     * @return operation result
+     */
+    outcome::result<void> decode(gsl::span<const uint8_t> input);
+
+    /**
+     * @brief Get Node content
+     * @return content data
+     */
+    const std::string &getContent() const;
+
+    /**
+     * @brief Get count of the children
+     * @return Links num
+     */
+    size_t getLinksCount() const;
+
+    /**
+     * @brief Get link to the children name
+     * @param index - id of the link
+     * @return operation result
+     */
+    const std::string &getLinkName(size_t index) const;
+
+    /**
+     * @brief Get CID of the children
+     * @param index - id of the link
+     * @return CID bytes
+     */
+    const std::string &getLinkCID(size_t index) const;
+
+    /**
+     * @brief Get name of the link to the children
+     * @param index - id of the link
+     * @return operation result
+     */
+    size_t getLinkSize(size_t index) const;
+
+   private:
+    ::merkledag::pb::PBNode pb_node_;
+  };
+
+  /**
+   * @enum Possible PBNodeDecoder errors
+   */
+  enum class PBNodeDecodeError { INVALID_RAW_BYTES = 1 };
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_HPP_DECLARE_ERROR(fc::storage::ipfs::merkledag, PBNodeDecodeError)
+
+#endif

--- a/core/storage/ipfs/merkledag/impl/pb_node_encoder.cpp
+++ b/core/storage/ipfs/merkledag/impl/pb_node_encoder.cpp
@@ -1,0 +1,122 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/pb_node_encoder.hpp"
+
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include "merkledag.pb.h"
+
+using google::protobuf::io::ArrayOutputStream;
+using google::protobuf::io::CodedOutputStream;
+using merkledag::pb::PBLink;
+using merkledag::pb::PBNode;
+
+namespace fc::storage::ipfs::merkledag {
+  common::Buffer PBNodeEncoder::encode(
+      const common::Buffer &content,
+      const std::map<std::string, LinkImpl> &links) {
+    common::Buffer data;
+    std::vector<uint8_t> links_pb = serializeLinks(links);
+    std::vector<uint8_t> content_pb = serializeContent(content);
+    data.put(links_pb);
+    data.put(content_pb);
+    return data;
+  }
+
+  size_t PBNodeEncoder::getLinkLengthPB(const std::string &name,
+                                        const Link &link) {
+    size_t length{};
+    size_t cid_bytes_size = link.getCID().content_address.toBuffer().size();
+    length += cid_bytes_size;
+    length += CodedOutputStream::VarintSize64(cid_bytes_size);
+    length += name.size();
+    length += CodedOutputStream::VarintSize64(name.size());
+    length += CodedOutputStream::VarintSize64(link.getSize());
+    length += sizeof(PBTag) * 3;  // Count of the PBLink fields
+    return length;
+  }
+
+  std::vector<uint8_t> PBNodeEncoder::serializeLinks(
+      const std::map<std::string, LinkImpl> &links) {
+    // Calculate links size:
+    size_t links_content_size{};
+    size_t links_headers_size{};
+    std::vector<size_t> links_size{};
+    for (const auto &link : links) {
+      links_size.push_back(getLinkLengthPB(link.first, link.second));
+      links_content_size += links_size.back();
+      links_headers_size += sizeof(PBTag);
+      links_headers_size += CodedOutputStream::VarintSize64(links_size.back());
+    }
+    if (links_content_size > 0) {
+      std::vector<uint8_t> buffer(links_content_size + links_headers_size);
+      ArrayOutputStream array_output_stream(buffer.data(), buffer.size());
+      CodedOutputStream coded_stream{&array_output_stream};
+      size_t link_index{};
+      for (const auto &link : links) {
+        PBTag links_tag = createTag(PBFieldType::LENGTH_DELEMITED,
+                                    static_cast<uint8_t>(PBNodeOrder::LINKS));
+        coded_stream.WriteTag(links_tag);
+        coded_stream.WriteVarint64(links_size.at(link_index));
+        // Write target Node's CID bytes:
+        const auto &cid_bytes = link.second.getCID().content_address.toBuffer();
+        PBTag cid_tag = createTag(PBFieldType::LENGTH_DELEMITED,
+                                  static_cast<uint8_t>(PBLinkOrder::HASH));
+        coded_stream.WriteTag(cid_tag);
+        coded_stream.WriteVarint64(cid_bytes.size());
+        coded_stream.WriteRaw(cid_bytes.data(), cid_bytes.size());
+        // Write link name:
+        PBTag name_tag = createTag(PBFieldType::LENGTH_DELEMITED,
+                                   static_cast<uint8_t>(PBLinkOrder::NAME));
+        coded_stream.WriteTag(name_tag);
+        coded_stream.WriteVarint64(link.first.size());
+        coded_stream.WriteRaw(link.first.data(), link.first.size());
+        // Write target Node's size:
+        PBTag size_tag = createTag(PBFieldType::VARINT,
+                                   static_cast<uint8_t>(PBLinkOrder::SIZE));
+        coded_stream.WriteTag(size_tag);
+        coded_stream.WriteVarint64(link.second.getSize());
+        ++link_index;
+      }
+      return buffer;
+    }
+    return {};
+  }
+
+  std::vector<uint8_t> PBNodeEncoder::serializeContent(
+      const common::Buffer &content) {
+    size_t pb_length = getContentLengthPB(content);
+    std::vector<uint8_t> buffer(pb_length);
+    if (pb_length > 0) {
+      ArrayOutputStream array_output_stream(buffer.data(), buffer.size());
+      PBTag data_tag = createTag(PBFieldType::LENGTH_DELEMITED,
+                                 static_cast<uint8_t>(PBNodeOrder::DATA));
+      CodedOutputStream coded_stream{&array_output_stream};
+      coded_stream.WriteTag(data_tag);
+      coded_stream.WriteVarint64(content.size());
+      coded_stream.WriteRaw(content.data(), content.size());
+    }
+    return buffer;
+  }
+
+  size_t PBNodeEncoder::getContentLengthPB(const common::Buffer &content) {
+    size_t length{};
+    if (!content.empty()) {
+      length += sizeof(PBTag);
+      length += CodedOutputStream::VarintSize64(content.size());
+      length += content.size();
+    }
+    return length;
+  }
+
+  PBNodeEncoder::PBTag PBNodeEncoder::createTag(PBFieldType type,
+                                                uint8_t order) {
+    constexpr size_t pb_type_length = 3;
+    uint8_t tag = (order << pb_type_length);
+    tag |= static_cast<uint8_t>(type);
+    return tag;
+  }
+}  // namespace fc::storage::ipfs::merkledag

--- a/core/storage/ipfs/merkledag/impl/pb_node_encoder.hpp
+++ b/core/storage/ipfs/merkledag/impl/pb_node_encoder.hpp
@@ -1,0 +1,98 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_PB_NODE_ENCODER
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_PB_NODE_ENCODER
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <gsl/span>
+#include "common/buffer.hpp"
+#include "common/outcome.hpp"
+#include "storage/ipfs/merkledag/impl/link_impl.hpp"
+#include "storage/ipfs/merkledag/node.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  /**
+   * @class Protobuf-serializer for MerkleDAG Nodes
+   * @details Order of parts of the Protobuf-serialized data is forced
+   *          specially for backward-compatibility with reference golang
+   *          implementation
+   * @warning Need to update serialization algorithm on Protobuf-scheme change
+   */
+  class PBNodeEncoder {
+   public:
+    /**
+     * @brief Serialize Node
+     * @param content - Node data
+     * @param links - references for child Nodes
+     * @return Protobuf-encoded data
+     */
+    static common::Buffer encode(const common::Buffer &content,
+                                 const std::map<std::string, LinkImpl> &links);
+
+   private:
+    using PBTag = uint8_t;
+
+    // Protobuf wire types
+    enum class PBFieldType : uint8_t {
+      VARINT = 0,
+      BITS_64,
+      LENGTH_DELEMITED,
+      START_GROUP,
+      END_GROUP,
+      BITS_32
+    };
+
+    enum class PBLinkOrder : uint8_t { HASH = 1, NAME, SIZE };
+
+    enum class PBNodeOrder : uint8_t { DATA = 1, LINKS };
+
+    // Serialized content
+    common::Buffer data_;
+
+    /**
+     * @brief Calculate length of the serialized link
+     * @param name - link name
+     * @param link - child link
+     * @return Number of bytes
+     */
+    static size_t getLinkLengthPB(const std::string &name, const Link &link);
+
+    /**
+     * @brief Calculate length of the serialized content
+     * @param content - Node's data
+     * @return Number of bytes
+     */
+    static size_t getContentLengthPB(const common::Buffer &content);
+
+    /**
+     * @brief Serialized Node's links
+     * @param links - Node's children
+     * @return Raw bytes
+     */
+    static std::vector<uint8_t> serializeLinks(
+        const std::map<std::string, LinkImpl> &links);
+
+    /**
+     * @brief Serialized Node's content
+     * @param content - Node's data
+     * @return Raw bytes
+     */
+    static std::vector<uint8_t> serializeContent(const common::Buffer &content);
+
+    /**
+     * @brief Create Protobuf filed header
+     * @param type - field type
+     * @param order - field order
+     * @return Tag value
+     */
+    static PBTag createTag(PBFieldType type, uint8_t order);
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+#endif

--- a/core/storage/ipfs/merkledag/impl/protobuf/merkledag.proto
+++ b/core/storage/ipfs/merkledag/impl/protobuf/merkledag.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+
+package merkledag.pb;
+
+// An IPFS MerkleDAG Link
+message PBLink {
+
+  // multihash of the target object
+  optional bytes Hash = 1;
+
+  // utf string name. should be unique per object
+  optional string Name = 2;
+
+  // cumulative size of target object
+  optional uint64 Tsize = 3;
+}
+
+// An IPFS MerkleDAG Node
+message PBNode {
+
+  // refs to other objects
+  repeated PBLink Links = 2;
+
+  // opaque user data
+  optional bytes Data = 1;
+}

--- a/core/storage/ipfs/merkledag/leaf.hpp
+++ b/core/storage/ipfs/merkledag/leaf.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_LEAF_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_LEAF_HPP
+
+#include <functional>
+#include <string_view>
+
+#include "common/buffer.hpp"
+#include "common/outcome.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  class Leaf {
+   public:
+    /**
+     * @brief Destructor
+     */
+    virtual ~Leaf() = default;
+
+    /**
+     * @brief Get leaf content
+     * @return operation result
+     */
+    virtual const common::Buffer &content() const = 0;
+
+    /**
+     * @brief Get count of children leaves
+     * @return Count of leaves
+     */
+    virtual size_t count() const = 0;
+
+    /**
+     * @brief Get children leaf
+     * @param name - leaf name
+     * @return operation result
+     */
+    virtual outcome::result<std::reference_wrapper<const Leaf>> subLeaf(
+        std::string_view name) const = 0;
+
+    /**
+     * @brief Get names of all sub leaves of the current leaf
+     * @return operation result
+     */
+    virtual std::vector<std::string_view> getSubLeafNames() const = 0;
+  };
+
+  /**
+   * @enum Possible leaf errors
+   */
+  enum class LeafError : int { LEAF_NOT_FOUND = 1, DUPLICATE_LEAF };
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_HPP_DECLARE_ERROR(fc::storage::ipfs::merkledag, LeafError)
+
+#endif

--- a/core/storage/ipfs/merkledag/link.hpp
+++ b/core/storage/ipfs/merkledag/link.hpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_LINK_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_LINK_HPP
+
+#include <string>
+#include <vector>
+
+#include "primitives/cid/cid.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  class Link {
+   public:
+    /**
+     * @brief Destructor
+     */
+    virtual ~Link() = default;
+
+    /**
+     * @brief Get name of the link
+     * @return Name, which should be unique per object
+     */
+    virtual const std::string &getName() const = 0;
+
+    /**
+     * @brief Get identifier of the target object
+     * @return Content identifier
+     */
+    virtual const CID &getCID() const = 0;
+
+    /**
+     * @brief Get target object size
+     * @return Cumulative size of the target object
+     */
+    virtual size_t getSize() const = 0;
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+#endif

--- a/core/storage/ipfs/merkledag/merkledag_service.hpp
+++ b/core/storage/ipfs/merkledag/merkledag_service.hpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_SERVICE_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_SERVICE_HPP
+
+#include <memory>
+
+#include "common/outcome.hpp"
+#include "storage/ipfs/blockservice.hpp"
+#include "storage/ipfs/merkledag/leaf.hpp"
+#include "storage/ipfs/merkledag/node.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  class MerkleDagService {
+   public:
+    /**
+     * @brief Destructor
+     */
+    virtual ~MerkleDagService() = default;
+
+    /**
+     * @brief Add new node
+     * @param node - entity to add
+     * @return operation result
+     */
+    virtual outcome::result<void> addNode(std::shared_ptr<const Node> node) = 0;
+
+    /**
+     * @brief Get node by id
+     * @param cid - node id
+     * @return operation result
+     */
+    virtual outcome::result<std::shared_ptr<Node>> getNode(
+        const CID &cid) const = 0;
+
+    /**
+     * @brief Remove node by id
+     * @param cid - node id
+     * @return operation result
+     */
+    virtual outcome::result<void> removeNode(const CID &cid) = 0;
+
+    /**
+     * @brief Fetcg graph from given root node
+     * @param cid - identifier of the root node
+     * @return operation result
+     */
+    virtual outcome::result<std::shared_ptr<Leaf>> fetchGraph(
+        const CID &cid) const = 0;
+
+    /**
+     * @brief Construct graph from given root node till chosen limit
+     *        (0 means "Fetch only root node")
+     * @param cid - identifier of the root node
+     * @param depth - limit of the depth to fetch
+     * @return operation result
+     */
+    virtual outcome::result<std::shared_ptr<Leaf>> fetchGraphOnDepth(
+        const CID &cid, uint64_t depth) const = 0;
+  };
+
+  /**
+   * @class Possible MerkleDAG service errors
+   */
+  enum class ServiceError {
+    UNRESOLVED_LINK = 1  // This error can occur if child node not found
+  };
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_HPP_DECLARE_ERROR(fc::storage::ipfs::merkledag, ServiceError)
+
+#endif

--- a/core/storage/ipfs/merkledag/node.hpp
+++ b/core/storage/ipfs/merkledag/node.hpp
@@ -1,0 +1,86 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FILECOIN_STORAGE_IPFS_MERKLEDAG_NODE_HPP
+#define FILECOIN_STORAGE_IPFS_MERKLEDAG_NODE_HPP
+
+#include <functional>
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "common/buffer.hpp"
+#include "common/outcome.hpp"
+#include "storage/ipfs/block.hpp"
+#include "storage/ipfs/merkledag/link.hpp"
+
+namespace fc::storage::ipfs::merkledag {
+  /**
+   * @interface MerkleDAG service node
+   */
+  class Node : public Block {
+   public:
+    /**
+     * @brief Total size of the data including the total sizes of references
+     * @return Cumulative size in bytes
+     */
+    virtual size_t size() const = 0;
+
+    /**
+     * @brief Assign Node's content
+     * @param input - data bytes
+     * @return operation result
+     */
+    virtual void assign(common::Buffer input) = 0;
+
+    /**
+     * @brief Get Node data
+     * @return content bytes
+     */
+    virtual const common::Buffer &content() const = 0;
+
+    /**
+     * @brief Add link to the child node
+     * @param name - name of the child node
+     * @param node - child object to link
+     * @return operation result
+     */
+    virtual outcome::result<void> addChild(const std::string &name,
+                                           std::shared_ptr<const Node> node) = 0;
+
+    /**
+     * @brief Get particular link to the child node
+     * @param name - id of the link
+     * @return Requested link of error, if link not found
+     */
+    virtual outcome::result<std::reference_wrapper<const Link>> getLink(
+        const std::string &name) const = 0;
+
+    /**
+     * @brief Remove link to the child node
+     * @param name - name of the child node
+     * @return operation result
+     */
+    virtual void removeLink(const std::string &name) = 0;
+
+    /**
+     * @brief Insert link to the child node
+     * @param link - object to add
+     */
+    virtual void addLink(const Link &link) = 0;
+
+    virtual std::vector<std::reference_wrapper<const Link>> getLinks()
+        const = 0;
+  };
+
+  /**
+   * @class Possible Node errors
+   */
+  enum class NodeError : int { LINK_NOT_FOUND, INVALID_RAW_DATA };
+}  // namespace fc::storage::ipfs::merkledag
+
+OUTCOME_HPP_DECLARE_ERROR(fc::storage::ipfs::merkledag, NodeError)
+
+#endif

--- a/test/core/storage/ipfs/CMakeLists.txt
+++ b/test/core/storage/ipfs/CMakeLists.txt
@@ -24,3 +24,5 @@ target_link_libraries(ipfs_blockservice_test
     ipfs_blockservice
     ipfs_datastore_in_memory
     )
+
+add_subdirectory(merkledag)

--- a/test/core/storage/ipfs/merkledag/CMakeLists.txt
+++ b/test/core/storage/ipfs/merkledag/CMakeLists.txt
@@ -1,0 +1,7 @@
+addtest(ipfs_merkledag_service_test
+    ipfs_merkledag_service_test.cpp
+    )
+target_link_libraries(ipfs_merkledag_service_test
+    ipfs_merkledag_service
+    buffer
+    )

--- a/test/core/storage/ipfs/merkledag/ipfs_merkledag_dataset.hpp
+++ b/test/core/storage/ipfs/merkledag/ipfs_merkledag_dataset.hpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CORE_STORAGE_IPFS_MERKLEDAG_NODE_LIBRARY
+#define CORE_STORAGE_IPFS_MERKLEDAG_NODE_LIBRARY
+
+#include <libp2p/multi/content_identifier_codec.hpp>
+#include "storage/ipfs/merkledag/impl/node_impl.hpp"
+#include "storage/ipfs/merkledag/node.hpp"
+
+namespace dataset {
+  using Node = fc::storage::ipfs::merkledag::Node;
+  using NodeImpl = fc::storage::ipfs::merkledag::NodeImpl;
+  using CIDCodec = libp2p::multi::ContentIdentifierCodec;
+
+  /**
+   * @brief Add child link for root node
+   * @param to - root node
+   * @param from - child node
+   * @return operation result
+   */
+  fc::outcome::result<void> link(const std::shared_ptr<Node> &to,
+                                 const std::shared_ptr<const Node> &from) {
+    OUTCOME_TRY(from_id, CIDCodec::toString(from->getCID()));
+    EXPECT_OUTCOME_TRUE_1(to->addChild(from_id, from));
+    return fc::outcome::success();
+  }
+
+  /**
+   * @brief Generate node suite type A
+   * @return Null node
+   */
+  std::vector<std::shared_ptr<Node>> getTypeA() {
+    return {NodeImpl::createFromString("")};
+  }
+
+  /**
+   * @brief Generate node suite type B
+   * @return Node without child
+   */
+  std::vector<std::shared_ptr<Node>> getTypeB() {
+    return {NodeImpl::createFromString("leve1_node1")};
+  }
+
+  /**
+   * @brief Generate node suite type C
+   * @return Node with one child
+   *                    []
+   *                    |
+   *              [leve1_node1]
+   */
+  std::vector<std::shared_ptr<Node>> getTypeC() {
+    auto root = NodeImpl::createFromString("");
+    auto child_1 = NodeImpl::createFromString("leve1_node1");
+    EXPECT_OUTCOME_TRUE_1(link(root, child_1));
+    return {root, child_1};
+  }
+
+  /**
+   * @brief Generate node suite type D
+   * @return Node with several childs child
+   *                 [leve1_node1]
+   *               /      |       \
+   * [leve2_node1]  [leve2_node2]  [leve2_node3]
+   *
+   */
+  std::vector<std::shared_ptr<Node>> getTypeD() {
+    auto root = NodeImpl::createFromString("leve1_node1");
+    auto child_1 = NodeImpl::createFromString("leve2_node1");
+    EXPECT_OUTCOME_TRUE_1(link(root, child_1));
+    auto child_2 = NodeImpl::createFromString("leve2_node2");
+    EXPECT_OUTCOME_TRUE_1(link(root, child_2));
+    auto child_3 = NodeImpl::createFromString("leve2_node3");
+    EXPECT_OUTCOME_TRUE_1(link(root, child_3));
+    return {root, child_1, child_2, child_3};
+  }
+
+  /**
+   * @brief Generate node suite type E
+   * @return Node with two child "branches" and node, which is child of two
+   * different parents
+   *                               [] ---------------
+   *                              / \               |
+   *                 [leve1_node1]   [leve1_node2]  |
+   *               /      |       \                 |
+   * [leve2_node1]  [leve2_node2]  [leve2_node3]-----
+   */
+  std::vector<std::shared_ptr<Node>> getTypeE() {
+    auto root = NodeImpl::createFromString("");
+    auto suite_D = getTypeD();
+    EXPECT_OUTCOME_TRUE_1(link(root, suite_D.front()));
+    auto child_1 = NodeImpl::createFromString("leve1_node2");
+    EXPECT_OUTCOME_TRUE_1(link(root, child_1));
+    EXPECT_OUTCOME_TRUE_1(link(root, suite_D.back()));
+    std::vector<std::shared_ptr<Node>> suite_E{root, child_1};
+    suite_E.insert(suite_E.end(), suite_D.begin(), suite_D.end());
+    return suite_E;
+  }
+}  // namespace dataset
+
+#endif

--- a/test/core/storage/ipfs/merkledag/ipfs_merkledag_service_test.cpp
+++ b/test/core/storage/ipfs/merkledag/ipfs_merkledag_service_test.cpp
@@ -1,0 +1,221 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage/ipfs/merkledag/impl/node_impl.hpp"
+
+#include <gtest/gtest.h>
+#include <libp2p/multi/content_identifier_codec.hpp>
+#include <storage/ipfs/merkledag/impl/merkledag_service_impl.hpp>
+#include <testutil/outcome.hpp>
+#include "core/storage/ipfs/merkledag/ipfs_merkledag_dataset.hpp"
+#include "storage/ipfs/impl/blockservice_impl.hpp"
+#include "storage/ipfs/impl/in_memory_datastore.hpp"
+
+using namespace fc::storage::ipfs;
+using namespace fc::storage::ipfs::merkledag;
+using libp2p::multi::ContentIdentifierCodec;
+
+/**
+ * @struct Test case dataset
+ */
+struct DataSample {
+  // Various-linked MerkleDAG nodes [root, node_1, node_2 ... ]
+  std::vector<std::shared_ptr<Node>> nodes;
+
+  // Base58-encoded CID of the root node from the Lotus implementation
+  std::string sample_cid;
+
+  // Graph structure, defined like: {} is node, [] is content, -> is children
+  std::string graph_structure;
+};
+
+/**
+ * @struct Test fixture for MerkleDAG service
+ */
+struct CommonFeaturesTest : public testing::TestWithParam<DataSample> {
+  // MerkleDAG service
+  std::shared_ptr<MerkleDagService> merkledag_service_{nullptr};
+
+  // Sample data for current test case
+  DataSample data;
+
+  /**
+   * @brief Prepare test suite
+   */
+  void SetUp() override {
+    std::shared_ptr<IpfsDatastore> datastore{new InMemoryDatastore{}};
+    std::shared_ptr<BlockService> blockservice{new BlockServiceImpl{datastore}};
+    merkledag_service_ = std::make_shared<MerkleDagServiceImpl>(blockservice);
+    data = GetParam();
+    EXPECT_OUTCOME_TRUE_1(this->saveToBlockService(data.nodes));
+  }
+
+  /**
+   * @brief Save nodes to the Block Service
+   * @param nodes - data to save
+   * @return operation result
+   */
+  fc::outcome::result<void> saveToBlockService(
+      const std::vector<std::shared_ptr<Node>> &nodes) {
+    for (const auto &node : nodes) {
+      EXPECT_OUTCOME_TRUE_1(merkledag_service_->addNode(node));
+    }
+    return fc::outcome::success();
+  }
+
+  /**
+   * @brief Get CID string representation node
+   * @param node - target for retrieving id
+   * @return Base58-encoded CID v0
+   */
+  static std::string cidToString(const std::shared_ptr<const Node> &node) {
+    std::string value{};
+    auto result = ContentIdentifierCodec::toString(node->getCID());
+    if (!result.has_error()) {
+      value = result.value();
+    }
+    return value;
+  }
+
+  /**
+   * @brief Generate graph structure
+   *        Node without content:  {[]}
+   *        Node without children: {[content]}
+   *        Node with children:    {[content]->{[children]}]
+   * @note  This serialized graph structure uses only for tests purposes
+   * @param leaf - root node
+   * @return operation result
+   */
+  static std::string getGraphStructure(const Leaf &leaf) {
+    std::string content{"{["};
+    std::string data{leaf.content().begin(), leaf.content().end()};
+    content.append(data);
+    content.push_back(']');
+    std::vector<std::string_view> leaves = leaf.getSubLeafNames();
+    if (!leaves.empty()) {
+      content.append("->");
+      for (const auto &leaf_id : leaves) {
+        EXPECT_OUTCOME_TRUE(sub_leaf, leaf.subLeaf(leaf_id))
+        content.append(getGraphStructure(sub_leaf));
+        content.push_back(',');
+      }
+      content.pop_back();
+    }
+    content.push_back('}');
+    return content;
+  }
+};
+
+/**
+ * @given Pre-generated nodes and reference CIDs
+ * @when Attempt to get stored node by CID
+ * @then MerkleDAG service returns requested node
+ */
+TEST_P(CommonFeaturesTest, GetNodeSuccess) {
+  for (const auto &node : data.nodes) {
+    EXPECT_OUTCOME_TRUE(received_node,
+                        merkledag_service_->getNode(node->getCID()))
+    ASSERT_EQ(cidToString(node), cidToString(received_node));
+  }
+}
+
+/**
+ * @given Pre-generated nodes and reference CIDs
+ * @when Calculating CID of the root node
+ * @then Calculated and reference CIDs must be equal
+ */
+TEST_P(CommonFeaturesTest, CheckCidAlgorithmSuccess) {
+  ASSERT_EQ(data.sample_cid, cidToString(data.nodes.front()));
+}
+
+/**
+ * @given Pre-generated nodes sets with children links
+ * @when Removing and restoring children links
+ * @then Attempt to retrieve removed link must be failed,
+ *       attempt to restore removed link must be successful,
+ *       attempt to restrieve restored link must be successful,
+ *       CIDs of the node before and after all operations must be equal
+ */
+TEST_P(CommonFeaturesTest, LinkOperationsConsistency) {
+  for (const auto &node : data.nodes) {
+    std::vector<std::reference_wrapper<const Link>> links = node->getLinks();
+    std::string primary_cid = cidToString(node);
+    for (const auto &link : links) {
+      LinkImpl link_impl{
+          link.get().getCID(), link.get().getName(), link.get().getSize()};
+      EXPECT_OUTCOME_TRUE(received_link, node->getLink(link.get().getName()));
+      std::ignore = received_link;
+      std::string link_name = link.get().getName();
+      node->removeLink(link_name);
+      EXPECT_OUTCOME_FALSE(null_result, node->getLink(link_name));
+      std::ignore = null_result;
+      node->addLink(link_impl);
+      EXPECT_OUTCOME_TRUE(restored_link, node->getLink(link_name));
+      std::ignore = restored_link;
+    }
+    std::string secondary_cid = cidToString(node);
+    ASSERT_EQ(primary_cid, secondary_cid);
+  }
+}
+
+/**
+ * @given Pre-generated node
+ * @when Removing node from MerkleDAG service
+ * @then Attempt to get removed node must be failed
+ */
+TEST_P(CommonFeaturesTest, GetInvalidNodeFail) {
+  const auto &cid = data.nodes.front()->getCID();
+  EXPECT_OUTCOME_TRUE_1(merkledag_service_->removeNode(cid));
+  EXPECT_OUTCOME_FALSE_1(merkledag_service_->getNode(cid));
+};
+
+/**
+ * @given Pre-generated node
+ * @when Retrieving non-existent link from node
+ * @then Attempt to get non-existent link must be failed
+ */
+TEST_P(CommonFeaturesTest, GetInvalidLinkFail) {
+  const auto &node = data.nodes.front();
+  std::string invalid_name = "non_existent_link_name";
+  EXPECT_OUTCOME_FALSE_1(node->getLink(invalid_name))
+}
+
+/**
+ * @given Pre-generated nodes structure and reference serialized structure
+ * @when Fetching node and all children recursively
+ * @then Serialized node structure and reference value must be equal
+ */
+TEST_P(CommonFeaturesTest, FetchGraphSuccess) {
+  const auto &root_cid = data.nodes.front()->getCID();
+  EXPECT_OUTCOME_TRUE(root_leaf, merkledag_service_->fetchGraph(root_cid))
+  std::string fetched_structure = getGraphStructure(*root_leaf);
+  ASSERT_EQ(fetched_structure, data.graph_structure);
+}
+
+/**
+ * Pre-generated nodes, CIDs and serialized graph structures
+ * Reference CIDs was generated by https://github.com/ipfs/go-merkledag
+ */
+INSTANTIATE_TEST_CASE_P(
+    PredefinedSamples,
+    CommonFeaturesTest,
+    testing::Values(
+        DataSample{dataset::getTypeA(),
+                   "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+                   "{[]}"},
+        DataSample{dataset::getTypeB(),
+                   "QmTq5KSpqFrzJTQ7LCDCr7GmKZrWW46pp2DSrW3WibgFV6",
+                   "{[leve1_node1]}"},
+        DataSample{dataset::getTypeC(),
+                   "Qmaybnje7u6r2suDoUehBqxJU8dQ3MKwrUJ5Bi7qt68rDg",
+                   "{[]->{[leve1_node1]}}"},
+        DataSample{
+            dataset::getTypeD(),
+            "QmWocGTL2xjWpckYEAHCAK3MES4MjGudmz8KAiYP9m7wEs",
+            "{[leve1_node1]->{[leve2_node2]},{[leve2_node1]},{[leve2_node3]}}"},
+        DataSample{dataset::getTypeE(),
+                   "QmaKbJN4obBb7D1Ko3Ar5xrsaon4HbFeiCMNAW9g94ufmo",
+                   "{[]->{[leve1_node1]->{[leve2_node2]},{[leve2_node1]},{["
+                   "leve2_node3]}},{[leve2_node3]},{[leve1_node2]}}"}));


### PR DESCRIPTION
### Description of the Change

IPFS MerkleDAG service provides functionality to store and retrieve **Node**s, which contain various-length data bytes and **Link**s to the children **Node**s. Each **Link** is a simple structure - CID of the children **Node**, name of the **Link** and total size of the serialized children **Node**.

Each **Node** is stored separately, so each children **Node** is stored in the same way, as a parent.

MerkleDAG service introduces additional type to represent graph-structure with content of all children **Node**s: **Leave**. This type is used for recursive fetch of all children **Node** with their content.

### Benefits

IPFS component for managing distributed pieces of data.

<!-- What benefits will be realized by the code change? -->
