### PR TITLE
Extend CID copy/move operations

### DIFF
--- a/core/codec/cbor/cbor_decode_stream.cpp
+++ b/core/codec/cbor/cbor_decode_stream.cpp
@@ -81,7 +81,7 @@ namespace fc::codec::cbor {
     if (maybe_cid.has_error()) {
       outcome::raise(CborDecodeError::INVALID_CID);
     }
-    cid = maybe_cid.value();
+    cid = std::move(maybe_cid.value());
     return *this;
   }
 

--- a/core/codec/cbor/cbor_encode_stream.cpp
+++ b/core/codec/cbor/cbor_encode_stream.cpp
@@ -40,7 +40,7 @@ namespace fc::codec::cbor {
     return *this;
   }
 
-  CborEncodeStream &CborEncodeStream::operator<<(const CID &cid) {
+  CborEncodeStream &CborEncodeStream::operator<<(const libp2p::multi::ContentIdentifier &cid) {
     auto maybe_cid_bytes = libp2p::multi::ContentIdentifierCodec::encode(cid);
     if (maybe_cid_bytes.has_error()) {
       outcome::raise(CborEncodeError::INVALID_CID);

--- a/core/codec/cbor/cbor_encode_stream.hpp
+++ b/core/codec/cbor/cbor_encode_stream.hpp
@@ -80,7 +80,7 @@ namespace fc::codec::cbor {
     /** Encodes string */
     CborEncodeStream &operator<<(const std::string &str);
     /** Encodes CID */
-    CborEncodeStream &operator<<(const CID &cid);
+    CborEncodeStream &operator<<(const libp2p::multi::ContentIdentifier &cid);
     /** Encodes list container encode substream */
     CborEncodeStream &operator<<(const CborEncodeStream &other);
     /** Encodes map container encode substream map */

--- a/core/primitives/cid/cid.cpp
+++ b/core/primitives/cid/cid.cpp
@@ -15,6 +15,40 @@ namespace fc {
 
   CID::CID(const ContentIdentifier &cid) : ContentIdentifier(cid) {}
 
+  CID::CID(ContentIdentifier &&cid) noexcept
+      : ContentIdentifier(
+          cid.version, cid.content_type, std::move(cid.content_address)) {}
+
+  CID::CID(Version version,
+           libp2p::multi::MulticodecType::Code content_type,
+           libp2p::multi::Multihash content_address)
+      : ContentIdentifier(version, content_type, std::move(content_address)) {}
+
+  CID &CID::operator=(CID &&cid) noexcept {
+    version = cid.version;
+    content_type = cid.content_type;
+    content_address = std::move(cid.content_address);
+    return *this;
+  }
+
+  CID &CID::operator=(const ContentIdentifier &cid) {
+    version = cid.version;
+    content_type = cid.content_type;
+    content_address = cid.content_address;
+    return *this;
+  }
+
+  CID::CID(CID &&cid) noexcept
+      : ContentIdentifier(
+          cid.version, cid.content_type, std::move(cid.content_address)) {}
+
+  CID &CID::operator=(ContentIdentifier &&cid) {
+    version = cid.version;
+    content_type = cid.content_type;
+    content_address = std::move(cid.content_address);
+    return *this;
+  }
+
   outcome::result<std::string> CID::toString() const {
     return libp2p::multi::ContentIdentifierCodec::toString(*this);
   }

--- a/core/primitives/cid/cid.hpp
+++ b/core/primitives/cid/cid.hpp
@@ -16,13 +16,35 @@ namespace fc {
     using ContentIdentifier::ContentIdentifier;
 
     /**
-     * ContentIdentifier is not default-constructible, but in some cases we need
+     * ContentIdentifier is not default-constructable, but in some cases we need
      * default value. This value can be used to initialize class member or local
      * variable. Trying to CBOR encode this value will yield error, to ensure
      * proper initialization.
      */
     CID();
-    CID(const ContentIdentifier &cid);
+
+    explicit CID(const ContentIdentifier &cid);
+
+    explicit CID(ContentIdentifier &&cid) noexcept;
+
+    CID(CID &&cid) noexcept;
+
+    CID(const CID &cid) = default;
+
+    CID(Version version,
+        libp2p::multi::MulticodecType::Code content_type,
+        libp2p::multi::Multihash content_address);
+
+    ~CID() = default;
+
+    CID &operator=(const CID&) = default;
+
+    CID &operator=(CID &&cid) noexcept;
+
+    CID &operator=(const ContentIdentifier &cid);
+
+    CID &operator=(ContentIdentifier &&cid);
+
     /**
      * @brief string-encodes cid
      * @return encoded value or error

--- a/test/testutil/cbor.hpp
+++ b/test/testutil/cbor.hpp
@@ -23,9 +23,10 @@ void expectEncodeAndReencode(const T &value,
 }
 
 inline auto operator""_cid(const char *c, size_t s) {
-  return libp2p::multi::ContentIdentifierCodec::decode(
-             fc::common::unhex(std::string_view(c, s)).value())
-      .value();
+  auto cid = libp2p::multi::ContentIdentifierCodec::decode(
+                 fc::common::unhex(std::string_view(c, s)).value())
+                 .value();
+  return fc::CID{std::move(cid)};
 }
 
 #endif  // CPP_FILECOIN_TEST_TESTUTIL_CBOR_HPP


### PR DESCRIPTION
### Description of the Change

Clang-Tidy requires mark "explicit" constructors, which have one argument.
Defining `explicit CID(const ContentIdentifier &cid)` caused the need to define additional copy/move constructors and assignment operators.
