### PR TITLE
Init actor VM method

### DIFF
--- a/core/primitives/address/address.cpp
+++ b/core/primitives/address/address.cpp
@@ -6,6 +6,7 @@
 #include "primitives/address/address.hpp"
 
 #include "common/visitor.hpp"
+#include "crypto/blake2/blake2b160.hpp"
 
 OUTCOME_CPP_DEFINE_CATEGORY(fc::primitives::address, AddressError, e) {
   using fc::primitives::address::AddressError;
@@ -23,6 +24,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(fc::primitives::address, AddressError, e) {
 }
 
 namespace fc::primitives::address {
+  using crypto::blake2b::blake2b_160;
 
   bool Address::isKeyType() const {
     return visit_in_place(
@@ -45,6 +47,11 @@ namespace fc::primitives::address {
   Address Address::makeFromId(uint64_t id) {
     // TODO(turuslan): FIL-118 remove hardcoded TESTNET
     return {TESTNET, id};
+  }
+
+  Address Address::makeActorExecAddress(gsl::span<const uint8_t> data) {
+    // TODO(turuslan): FIL-118 remove hardcoded TESTNET
+    return {TESTNET, ActorExecHash{blake2b_160(data).value()}};
   }
 
   bool operator==(const Address &lhs, const Address &rhs) {

--- a/core/primitives/address/address.hpp
+++ b/core/primitives/address/address.hpp
@@ -68,6 +68,8 @@ namespace fc::primitives::address {
     /// id - number assigned to actors in a Filecoin Chain
     static Address makeFromId(uint64_t id);
 
+    static Address makeActorExecAddress(gsl::span<const uint8_t> data);
+
     Network network;
     Payload data;
   };

--- a/core/vm/actor/actor_method.hpp
+++ b/core/vm/actor/actor_method.hpp
@@ -23,6 +23,9 @@ namespace fc::vm::actor {
   /// Actor methods exported by number
   using ActorExports = std::map<MethodNumber, ActorMethod>;
 
+  /// Reserved method number for constructor
+  constexpr MethodNumber kConstructorMethodNumber{1};
+
   constexpr VMExitCode DECODE_ACTOR_PARAMS_ERROR{1};
 
   /// Decode actor params, raises appropriate error

--- a/core/vm/actor/cron_actor.cpp
+++ b/core/vm/actor/cron_actor.cpp
@@ -6,15 +6,8 @@
 #include "vm/actor/cron_actor.hpp"
 
 namespace fc::vm::actor {
-
-  using vm::actor::MethodNumber;
-  using vm::runtime::InvocationOutput;
-  using vm::runtime::Runtime;
-
-  constexpr MethodNumber kEpochTickMethodNumber{2};
-
   std::vector<CronTableEntry> CronActor::entries = {
-      {kStoragePowerAddress, SpaMethods::CHECK_PROOF_SUBMISSIONS}};
+      {kStoragePowerAddress, {SpaMethods::CHECK_PROOF_SUBMISSIONS}}};
 
   outcome::result<InvocationOutput> CronActor::epochTick(
       const Actor &actor, Runtime &runtime, const MethodParams &params) {
@@ -29,6 +22,6 @@ namespace fc::vm::actor {
   }
 
   ActorExports CronActor::exports = {
-      {kEpochTickMethodNumber, ActorMethod(CronActor::epochTick)},
+      {CronActor::kEpochTickMethodNumber, ActorMethod(CronActor::epochTick)},
   };
 }  // namespace fc::vm::actor

--- a/core/vm/actor/cron_actor.cpp
+++ b/core/vm/actor/cron_actor.cpp
@@ -11,7 +11,7 @@ namespace fc::vm::actor {
 
   outcome::result<InvocationOutput> CronActor::epochTick(
       const Actor &actor, Runtime &runtime, const MethodParams &params) {
-    if ((runtime.getMessage()->from != kCronAddress)) {
+    if ((runtime.getMessage().get().from != kCronAddress)) {
       return WRONG_CALL;
     }
 

--- a/core/vm/actor/cron_actor.cpp
+++ b/core/vm/actor/cron_actor.cpp
@@ -5,14 +5,15 @@
 
 #include "vm/actor/cron_actor.hpp"
 
-namespace fc::vm::actor {
-  std::vector<CronTableEntry> CronActor::entries = {
+namespace fc::vm::actor::cron_actor {
+  std::vector<CronTableEntry> entries = {
       {kStoragePowerAddress, {SpaMethods::CHECK_PROOF_SUBMISSIONS}}};
 
-  outcome::result<InvocationOutput> CronActor::epochTick(
-      const Actor &actor, Runtime &runtime, const MethodParams &params) {
+  outcome::result<InvocationOutput> epochTick(const Actor &actor,
+                                              Runtime &runtime,
+                                              const MethodParams &params) {
     if ((runtime.getMessage().get().from != kCronAddress)) {
-      return WRONG_CALL;
+      return cron_actor::WRONG_CALL;
     }
 
     for (const auto &entry : entries) {
@@ -21,7 +22,7 @@ namespace fc::vm::actor {
     return outcome::success();
   }
 
-  ActorExports CronActor::exports = {
-      {CronActor::kEpochTickMethodNumber, ActorMethod(CronActor::epochTick)},
+  ActorExports exports = {
+      {kEpochTickMethodNumber, ActorMethod(epochTick)},
   };
-}  // namespace fc::vm::actor
+}  // namespace fc::vm::actor::cron_actor

--- a/core/vm/actor/cron_actor.cpp
+++ b/core/vm/actor/cron_actor.cpp
@@ -6,6 +6,10 @@
 #include "vm/actor/cron_actor.hpp"
 
 namespace fc::vm::actor::cron_actor {
+  /**
+   * Entries is a set of actors (and corresponding methods) to call during
+   * EpochTick
+   */
   std::vector<CronTableEntry> entries = {
       {kStoragePowerAddress, {SpaMethods::CHECK_PROOF_SUBMISSIONS}}};
 

--- a/core/vm/actor/cron_actor.hpp
+++ b/core/vm/actor/cron_actor.hpp
@@ -10,16 +10,13 @@
 #include "vm/actor/storage_power_actor.hpp"
 
 namespace fc::vm::actor {
-
-  using runtime::InvocationOutput;
-  using runtime::Runtime;
-
   struct CronTableEntry {
     Address to_addr;
     MethodNumber method_num{};
   };
 
   struct CronActor {
+    static constexpr MethodNumber kEpochTickMethodNumber{2};
     static constexpr VMExitCode WRONG_CALL{1};
 
     /**

--- a/core/vm/actor/cron_actor.hpp
+++ b/core/vm/actor/cron_actor.hpp
@@ -19,12 +19,6 @@ namespace fc::vm::actor::cron_actor {
   constexpr VMExitCode WRONG_CALL{1};
 
   /**
-   * Entries is a set of actors (and corresponding methods) to call during
-   * EpochTick
-   */
-  extern std::vector<CronTableEntry> entries;
-
-  /**
    * @brief EpochTick executes built-in periodic actions, run at every Epoch.
    * @param actor from Lotus(doesn't use)
    * @param runtime is virtual machine context

--- a/core/vm/actor/cron_actor.hpp
+++ b/core/vm/actor/cron_actor.hpp
@@ -9,35 +9,34 @@
 #include "vm/actor/actor_method.hpp"
 #include "vm/actor/storage_power_actor.hpp"
 
-namespace fc::vm::actor {
+namespace fc::vm::actor::cron_actor {
   struct CronTableEntry {
     Address to_addr;
     MethodNumber method_num{};
   };
 
-  struct CronActor {
-    static constexpr MethodNumber kEpochTickMethodNumber{2};
-    static constexpr VMExitCode WRONG_CALL{1};
+  constexpr MethodNumber kEpochTickMethodNumber{2};
+  constexpr VMExitCode WRONG_CALL{1};
 
-    /**
-     * Entries is a set of actors (and corresponding methods) to call during
-     * EpochTick
-     */
-    static std::vector<CronTableEntry> entries;
+  /**
+   * Entries is a set of actors (and corresponding methods) to call during
+   * EpochTick
+   */
+  extern std::vector<CronTableEntry> entries;
 
-    /**
-     * @brief EpochTick executes built-in periodic actions, run at every Epoch.
-     * @param actor from Lotus(doesn't use)
-     * @param runtime is virtual machine context
-     * @param params from Lotus(doesn't use)
-     * @return success or error
-     */
-    static outcome::result<InvocationOutput> epochTick(
-        const Actor &actor, Runtime &runtime, const MethodParams &params);
+  /**
+   * @brief EpochTick executes built-in periodic actions, run at every Epoch.
+   * @param actor from Lotus(doesn't use)
+   * @param runtime is virtual machine context
+   * @param params from Lotus(doesn't use)
+   * @return success or error
+   */
+  outcome::result<InvocationOutput> epochTick(const Actor &actor,
+                                              Runtime &runtime,
+                                              const MethodParams &params);
 
-    static ActorExports exports;
-  };
+  extern ActorExports exports;
 
-}  // namespace fc::vm::actor
+}  // namespace fc::vm::actor::cron_actor
 
 #endif  // CPP_FILECOIN_CORE_VM_ACTOR_CRON_ACTOR_HPP

--- a/core/vm/actor/impl/invoker_impl.cpp
+++ b/core/vm/actor/impl/invoker_impl.cpp
@@ -6,6 +6,7 @@
 #include "vm/actor/impl/invoker_impl.hpp"
 
 #include "vm/actor/cron_actor.hpp"
+#include "vm/actor/init_actor.hpp"
 
 namespace fc::vm::actor {
 
@@ -13,6 +14,7 @@ namespace fc::vm::actor {
 
   InvokerImpl::InvokerImpl() {
     builtin_[actor::kCronCodeCid] = actor::cron_actor::exports;
+    builtin_[actor::kInitCodeCid] = actor::init_actor::exports;
   }
 
   outcome::result<InvocationOutput> InvokerImpl::invoke(

--- a/core/vm/actor/impl/invoker_impl.cpp
+++ b/core/vm/actor/impl/invoker_impl.cpp
@@ -12,7 +12,7 @@ namespace fc::vm::actor {
   using runtime::InvocationOutput;
 
   InvokerImpl::InvokerImpl() {
-    builtin_[actor::kCronCodeCid] = actor::CronActor::exports;
+    builtin_[actor::kCronCodeCid] = actor::cron_actor::exports;
   }
 
   outcome::result<InvocationOutput> InvokerImpl::invoke(

--- a/core/vm/actor/init_actor.cpp
+++ b/core/vm/actor/init_actor.cpp
@@ -9,7 +9,7 @@
 #include "storage/hamt/hamt.hpp"
 #include "vm/runtime/gas_cost.hpp"
 
-namespace fc::vm::actor {
+namespace fc::vm::actor::init_actor {
   outcome::result<Address> InitActorState::addActor(
       std::shared_ptr<IpfsDatastore> store, const Address &address) {
     storage::hamt::Hamt hamt(std::move(store), address_map);
@@ -21,14 +21,15 @@ namespace fc::vm::actor {
     return Address::makeFromId(id);
   }
 
-  outcome::result<InvocationOutput> InitActor::exec(
-      const Actor &actor, Runtime &runtime, const MethodParams &params) {
+  outcome::result<InvocationOutput> exec(const Actor &actor,
+                                         Runtime &runtime,
+                                         const MethodParams &params) {
     OUTCOME_TRY(exec_params, decodeActorParams<ExecParams>(params));
     if (!isBuiltinActor(exec_params.code)) {
-      return InitActor::NOT_BUILTIN_ACTOR;
+      return init_actor::NOT_BUILTIN_ACTOR;
     }
     if (isSingletonActor(exec_params.code)) {
-      return InitActor::SINGLETON_ACTOR;
+      return init_actor::SINGLETON_ACTOR;
     }
     OUTCOME_TRY(runtime.chargeGas(runtime::kInitActorExecCost));
     auto &message = runtime.getMessage().get();
@@ -51,6 +52,5 @@ namespace fc::vm::actor {
     return InvocationOutput{Buffer{primitives::address::encode(id_address)}};
   }
 
-  ActorExports InitActor::exports{
-      {InitActor::kExecMethodNumber, ActorMethod(InitActor::exec)}};
-}  // namespace fc::vm::actor
+  ActorExports exports{{kExecMethodNumber, ActorMethod(exec)}};
+}  // namespace fc::vm::actor::init_actor

--- a/core/vm/actor/init_actor.cpp
+++ b/core/vm/actor/init_actor.cpp
@@ -23,7 +23,6 @@ namespace fc::vm::actor {
 
   outcome::result<InvocationOutput> InitActor::exec(
       const Actor &actor, Runtime &runtime, const MethodParams &params) {
-    auto message = runtime.getMessage();
     OUTCOME_TRY(exec_params, decodeActorParams<ExecParams>(params));
     if (!isBuiltinActor(exec_params.code)) {
       return NOT_BUILTIN_ACTOR;
@@ -32,12 +31,12 @@ namespace fc::vm::actor {
       return SINGLETON_ACTOR;
     }
     OUTCOME_TRY(runtime.chargeGas(runtime::kInitActorExecCost));
+    auto message = runtime.getMessage();
     auto actor_address{Address::makeActorExecAddress(
         Buffer{primitives::address::encode(message->from)}.putUint64(
             message->nonce))};
     auto store = runtime.getIpfsDatastore();
-    auto head = actor.head;
-    OUTCOME_TRY(init_actor, store->getCbor<InitActorState>(head));
+    OUTCOME_TRY(init_actor, store->getCbor<InitActorState>(runtime.getHead()));
     OUTCOME_TRY(id_address, init_actor.addActor(store, actor_address));
     OUTCOME_TRY(runtime.createActor(
         id_address, Actor{exec_params.code, ActorSubstateCID{kEmptyObjectCid}, 0, 0}));
@@ -46,6 +45,7 @@ namespace fc::vm::actor {
                              exec_params.params,
                              message->value));
     OUTCOME_TRY(new_head, store->setCbor(init_actor));
+    OUTCOME_TRY(runtime.commit(ActorSubstateCID{new_head}));
     return InvocationOutput{Buffer{primitives::address::encode(id_address)}};
   }
 

--- a/core/vm/actor/init_actor.cpp
+++ b/core/vm/actor/init_actor.cpp
@@ -36,7 +36,8 @@ namespace fc::vm::actor {
         Buffer{primitives::address::encode(message.from)}.putUint64(
             message.nonce))};
     auto store = runtime.getIpfsDatastore();
-    OUTCOME_TRY(init_actor, store->getCbor<InitActorState>(runtime.getHead()));
+    OUTCOME_TRY(init_actor,
+                store->getCbor<InitActorState>(runtime.getCurrentActorState()));
     OUTCOME_TRY(id_address, init_actor.addActor(store, actor_address));
     OUTCOME_TRY(runtime.createActor(
         id_address,
@@ -45,8 +46,8 @@ namespace fc::vm::actor {
                              kConstructorMethodNumber,
                              exec_params.params,
                              message.value));
-    OUTCOME_TRY(new_head, store->setCbor(init_actor));
-    OUTCOME_TRY(runtime.commit(ActorSubstateCID{new_head}));
+    OUTCOME_TRY(new_state, store->setCbor(init_actor));
+    OUTCOME_TRY(runtime.commit(ActorSubstateCID{new_state}));
     return InvocationOutput{Buffer{primitives::address::encode(id_address)}};
   }
 

--- a/core/vm/actor/init_actor.hpp
+++ b/core/vm/actor/init_actor.hpp
@@ -9,7 +9,7 @@
 #include "storage/ipfs/datastore.hpp"
 #include "vm/actor/actor_method.hpp"
 
-namespace fc::vm::actor {
+namespace fc::vm::actor::init_actor {
   using storage::ipfs::IpfsDatastore;
 
   /// Init actor state
@@ -37,37 +37,35 @@ namespace fc::vm::actor {
     return s;
   }
 
-  struct InitActor {
-    static constexpr MethodNumber kExecMethodNumber{2};
-    static constexpr VMExitCode NOT_BUILTIN_ACTOR{1};
-    static constexpr VMExitCode SINGLETON_ACTOR{1};
+  constexpr MethodNumber kExecMethodNumber{2};
+  constexpr VMExitCode NOT_BUILTIN_ACTOR{1};
+  constexpr VMExitCode SINGLETON_ACTOR{1};
 
-    struct ExecParams {
-      CodeId code;
-      MethodParams params;
-    };
-
-    static outcome::result<InvocationOutput> exec(const Actor &actor,
-                                                  Runtime &runtime,
-                                                  const MethodParams &params);
-
-    static ActorExports exports;
+  struct ExecParams {
+    CodeId code;
+    MethodParams params;
   };
+
+  outcome::result<InvocationOutput> exec(const Actor &actor,
+                                         Runtime &runtime,
+                                         const MethodParams &params);
+
+  extern ActorExports exports;
 
   template <class Stream,
             typename = std::enable_if_t<
                 std::remove_reference_t<Stream>::is_cbor_encoder_stream>>
-  Stream &operator<<(Stream &&s, const InitActor::ExecParams &params) {
+  Stream &operator<<(Stream &&s, const ExecParams &params) {
     return s << (s.list() << params.code << params.params);
   }
 
   template <class Stream,
             typename = std::enable_if_t<
                 std::remove_reference_t<Stream>::is_cbor_decoder_stream>>
-  Stream &operator>>(Stream &&s, InitActor::ExecParams &params) {
+  Stream &operator>>(Stream &&s, ExecParams &params) {
     s.list() >> params.code >> params.params;
     return s;
   }
-}  // namespace fc::vm::actor
+}  // namespace fc::vm::actor::init_actor
 
 #endif  // CPP_FILECOIN_CORE_VM_ACTOR_INIT_ACTOR_HPP

--- a/core/vm/runtime/gas_cost.hpp
+++ b/core/vm/runtime/gas_cost.hpp
@@ -105,6 +105,7 @@ namespace fc::vm::runtime {
    */
   inline static const BigInt kCommitGasCost{50};
 
+  inline static const BigInt kInitActorExecCost{100};
 }  // namespace fc::vm::runtime
 
 #endif  // CPP_FILECOIN_CORE_VM_RUNTIME_GAS_COST_HPP

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -45,7 +45,7 @@ RuntimeImpl::RuntimeImpl(
     Address block_miner,
     BigInt gas_available,
     BigInt gas_used,
-    const ActorSubstateCID &actor_head)
+    ActorSubstateCID actor_head)
     : randomness_provider_{std::move(randomness_provider)},
       datastore_{std::move(datastore)},
       state_tree_{std::move(state_tree)},
@@ -57,7 +57,7 @@ RuntimeImpl::RuntimeImpl(
       block_miner_{std::move(block_miner)},
       gas_available_{std::move(gas_available)},
       gas_used_{std::move(gas_used)},
-      actor_head_{actor_head} {}
+      actor_head_{std::move(actor_head)} {}
 
 ChainEpoch RuntimeImpl::getCurrentEpoch() const {
   return chain_epoch_;

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -45,7 +45,7 @@ RuntimeImpl::RuntimeImpl(
     Address block_miner,
     BigInt gas_available,
     BigInt gas_used,
-    ActorSubstateCID actor_head)
+    ActorSubstateCID current_actor_state)
     : randomness_provider_{std::move(randomness_provider)},
       datastore_{std::move(datastore)},
       state_tree_{std::move(state_tree)},
@@ -57,7 +57,7 @@ RuntimeImpl::RuntimeImpl(
       block_miner_{std::move(block_miner)},
       gas_available_{std::move(gas_available)},
       gas_used_{std::move(gas_used)},
-      actor_head_{std::move(actor_head)} {}
+      current_actor_state_{std::move(current_actor_state)} {}
 
 ChainEpoch RuntimeImpl::getCurrentEpoch() const {
   return chain_epoch_;
@@ -202,14 +202,14 @@ std::reference_wrapper<const UnsignedMessage> RuntimeImpl::getMessage() {
   return message_;
 }
 
-ActorSubstateCID RuntimeImpl::getHead() {
-  return actor_head_;
+ActorSubstateCID RuntimeImpl::getCurrentActorState() {
+  return current_actor_state_;
 }
 
 fc::outcome::result<void> RuntimeImpl::commit(
-    const ActorSubstateCID &new_head) {
+    const ActorSubstateCID &new_state) {
   OUTCOME_TRY(chargeGas(kCommitGasCost));
-  actor_head_ = new_head;
+  current_actor_state_ = new_state;
   return outcome::success();
 }
 
@@ -241,7 +241,8 @@ fc::outcome::result<Actor> RuntimeImpl::getOrCreateActor(
 }
 
 std::shared_ptr<Runtime> RuntimeImpl::createRuntime(
-    const UnsignedMessage &message, const ActorSubstateCID &actor_head) const {
+    const UnsignedMessage &message,
+    const ActorSubstateCID &current_actor_state) const {
   return std::make_shared<RuntimeImpl>(randomness_provider_,
                                        datastore_,
                                        state_tree_,
@@ -253,5 +254,5 @@ std::shared_ptr<Runtime> RuntimeImpl::createRuntime(
                                        block_miner_,
                                        gas_available_,
                                        gas_used_,
-                                       actor_head);
+                                       current_actor_state);
 }

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -165,16 +165,14 @@ fc::outcome::result<InvocationOutput> RuntimeImpl::send(
   return res;
 }
 
-fc::outcome::result<void> RuntimeImpl::createActor(CodeId code_id,
-                                                   const Address &address) {
+fc::outcome::result<void> RuntimeImpl::createActor(const Address &address,
+                                                   const Actor &actor) {
   // May only be called by InitActor
   OUTCOME_TRY(actor_caller, state_tree_->get(immediate_caller_));
   if (actor_caller.code != actor::kInitCodeCid)
     return fc::outcome::failure(
         RuntimeError::CREATE_ACTOR_OPERATION_NOT_PERMITTED);
-
-  Actor new_actor{code_id, ActorSubstateCID(), 0, 0};
-  OUTCOME_TRY(state_tree_->registerNewAddress(address, new_actor));
+  OUTCOME_TRY(state_tree_->set(address, actor));
   return fc::outcome::success();
 }
 

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -95,11 +95,12 @@ namespace fc::vm::runtime {
     /** \copydoc Runtime::getMessage() */
     std::shared_ptr<UnsignedMessage> getMessage() override;
 
+    outcome::result<void> chargeGas(const BigInt &amount) override;
+
    private:
     outcome::result<void> transfer(Actor &from,
                                    Actor &to,
                                    const BigInt &amount);
-    outcome::result<void> chargeGas(const BigInt &amount);
     outcome::result<Actor> getOrCreateActor(const Address &address);
     std::shared_ptr<Runtime> createRuntime(
         const std::shared_ptr<UnsignedMessage> &message) const;

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -37,7 +37,8 @@ namespace fc::vm::runtime {
                 Address immediate_caller,
                 Address block_miner,
                 BigInt gas_available,
-                BigInt gas_used);
+                BigInt gas_used,
+                const ActorSubstateCID &actor_head);
 
     /** \copydoc Runtime::getCurrentEpoch() */
     ChainEpoch getCurrentEpoch() const override;
@@ -97,13 +98,18 @@ namespace fc::vm::runtime {
 
     outcome::result<void> chargeGas(const BigInt &amount) override;
 
+    ActorSubstateCID getHead() override;
+
+    outcome::result<void> commit(const ActorSubstateCID &new_head) override;
+
    private:
     outcome::result<void> transfer(Actor &from,
                                    Actor &to,
                                    const BigInt &amount);
     outcome::result<Actor> getOrCreateActor(const Address &address);
     std::shared_ptr<Runtime> createRuntime(
-        const std::shared_ptr<UnsignedMessage> &message) const;
+        const std::shared_ptr<UnsignedMessage> &message,
+        const ActorSubstateCID &actor_head) const;
 
    private:
     std::shared_ptr<RandomnessProvider> randomness_provider_;
@@ -118,6 +124,7 @@ namespace fc::vm::runtime {
     BigInt gas_price_;
     BigInt gas_available_;
     BigInt gas_used_;
+    ActorSubstateCID actor_head_;
   };
 
 }  // namespace fc::vm::runtime

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -38,7 +38,7 @@ namespace fc::vm::runtime {
                 Address block_miner,
                 BigInt gas_available,
                 BigInt gas_used,
-                const ActorSubstateCID &actor_head);
+                ActorSubstateCID actor_head);
 
     /** \copydoc Runtime::getCurrentEpoch() */
     ChainEpoch getCurrentEpoch() const override;

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -38,7 +38,7 @@ namespace fc::vm::runtime {
                 Address block_miner,
                 BigInt gas_available,
                 BigInt gas_used,
-                ActorSubstateCID actor_head);
+                ActorSubstateCID current_actor_state);
 
     /** \copydoc Runtime::getCurrentEpoch() */
     ChainEpoch getCurrentEpoch() const override;
@@ -98,9 +98,9 @@ namespace fc::vm::runtime {
 
     outcome::result<void> chargeGas(const BigInt &amount) override;
 
-    ActorSubstateCID getHead() override;
+    ActorSubstateCID getCurrentActorState() override;
 
-    outcome::result<void> commit(const ActorSubstateCID &new_head) override;
+    outcome::result<void> commit(const ActorSubstateCID &new_state) override;
 
    private:
     outcome::result<void> transfer(Actor &from,
@@ -109,7 +109,7 @@ namespace fc::vm::runtime {
     outcome::result<Actor> getOrCreateActor(const Address &address);
     std::shared_ptr<Runtime> createRuntime(
         const UnsignedMessage &message,
-        const ActorSubstateCID &actor_head) const;
+        const ActorSubstateCID &current_actor_state) const;
 
    private:
     std::shared_ptr<RandomnessProvider> randomness_provider_;
@@ -124,7 +124,7 @@ namespace fc::vm::runtime {
     BigInt gas_price_;
     BigInt gas_available_;
     BigInt gas_used_;
-    ActorSubstateCID actor_head_;
+    ActorSubstateCID current_actor_state_;
   };
 
 }  // namespace fc::vm::runtime

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -83,8 +83,8 @@ namespace fc::vm::runtime {
                                                BigInt value) override;
 
     /** \copydoc Runtime::createActor() */
-    outcome::result<void> createActor(CodeId code_id,
-                                      const Address &address) override;
+    outcome::result<void> createActor(const Address &address,
+                                      const Actor &actor) override;
 
     /** \copydoc Runtime::deleteActor() */
     outcome::result<void> deleteActor(const Address &address) override;

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -32,7 +32,7 @@ namespace fc::vm::runtime {
                 std::shared_ptr<StateTree> state_tree,
                 std::shared_ptr<Indices> indices,
                 std::shared_ptr<Invoker> invoker,
-                std::shared_ptr<UnsignedMessage> message,
+                UnsignedMessage message,
                 ChainEpoch chain_epoch,
                 Address immediate_caller,
                 Address block_miner,
@@ -94,7 +94,7 @@ namespace fc::vm::runtime {
     std::shared_ptr<IpfsDatastore> getIpfsDatastore() override;
 
     /** \copydoc Runtime::getMessage() */
-    std::shared_ptr<UnsignedMessage> getMessage() override;
+    std::reference_wrapper<const UnsignedMessage> getMessage() override;
 
     outcome::result<void> chargeGas(const BigInt &amount) override;
 
@@ -108,7 +108,7 @@ namespace fc::vm::runtime {
                                    const BigInt &amount);
     outcome::result<Actor> getOrCreateActor(const Address &address);
     std::shared_ptr<Runtime> createRuntime(
-        const std::shared_ptr<UnsignedMessage> &message,
+        const UnsignedMessage &message,
         const ActorSubstateCID &actor_head) const;
 
    private:
@@ -117,7 +117,7 @@ namespace fc::vm::runtime {
     std::shared_ptr<StateTree> state_tree_;
     std::shared_ptr<Indices> indices_;
     std::shared_ptr<Invoker> invoker_;
-    std::shared_ptr<UnsignedMessage> message_;
+    UnsignedMessage message_;
     ChainEpoch chain_epoch_;
     Address immediate_caller_;
     Address block_miner_;

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -134,6 +134,10 @@ namespace fc::vm::runtime {
     virtual std::shared_ptr<UnsignedMessage> getMessage() = 0;
 
     virtual outcome::result<void> chargeGas(const BigInt &amount) = 0;
+
+    virtual ActorSubstateCID getHead() = 0;
+
+    virtual outcome::result<void> commit(const ActorSubstateCID &new_head) = 0;
   };
 
 }  // namespace fc::vm::runtime

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -130,6 +130,8 @@ namespace fc::vm::runtime {
      * @return message invoking current execution
      */
     virtual std::shared_ptr<UnsignedMessage> getMessage() = 0;
+
+    virtual outcome::result<void> chargeGas(const BigInt &amount) = 0;
   };
 
 }  // namespace fc::vm::runtime

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -131,7 +131,7 @@ namespace fc::vm::runtime {
      * Get Message for actor invocation
      * @return message invoking current execution
      */
-    virtual std::shared_ptr<UnsignedMessage> getMessage() = 0;
+    virtual std::reference_wrapper<const UnsignedMessage> getMessage() = 0;
 
     virtual outcome::result<void> chargeGas(const BigInt &amount) = 0;
 

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -22,6 +22,7 @@
 
 namespace fc::vm::runtime {
 
+  using actor::Actor;
   using actor::CodeId;
   using actor::MethodNumber;
   using actor::MethodParams;
@@ -104,12 +105,13 @@ namespace fc::vm::runtime {
     /**
      * @brief Creates an actor in the state tree, with empty state. May only be
      * called by InitActor
-     * @param code_id - the new actor's code identifier
+     * @brief Saves an actor in the state tree. May only be called by InitActor
      * @param address - Address under which the new actor's state will be
      * stored. Must be an ID-address
+     * @param actor - Actor state
      */
-    virtual outcome::result<void> createActor(CodeId code_id,
-                                              const Address &address) = 0;
+    virtual outcome::result<void> createActor(const Address &address,
+                                              const Actor &actor) = 0;
 
     /**
      * @brief Deletes an actor in the state tree

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -105,7 +105,6 @@ namespace fc::vm::runtime {
     /**
      * @brief Creates an actor in the state tree, with empty state. May only be
      * called by InitActor
-     * @brief Saves an actor in the state tree. May only be called by InitActor
      * @param address - Address under which the new actor's state will be
      * stored. Must be an ID-address
      * @param actor - Actor state
@@ -133,11 +132,14 @@ namespace fc::vm::runtime {
      */
     virtual std::reference_wrapper<const UnsignedMessage> getMessage() = 0;
 
+    /// Try to charge gas or throw if there is not enoght gas
     virtual outcome::result<void> chargeGas(const BigInt &amount) = 0;
 
-    virtual ActorSubstateCID getHead() = 0;
+    /// Get current actor state
+    virtual ActorSubstateCID getCurrentActorState() = 0;
 
-    virtual outcome::result<void> commit(const ActorSubstateCID &new_head) = 0;
+    /// Update actor state
+    virtual outcome::result<void> commit(const ActorSubstateCID &new_state) = 0;
   };
 
 }  // namespace fc::vm::runtime

--- a/core/vm/runtime/runtime_types.hpp
+++ b/core/vm/runtime/runtime_types.hpp
@@ -27,6 +27,11 @@ namespace fc::vm::runtime {
     common::Buffer return_value;
   };
 
+  inline bool operator==(const InvocationOutput &lhs,
+                         const InvocationOutput &rhs) {
+    return lhs.return_value == rhs.return_value;
+  }
+
   /**
    * Id of native function
    */

--- a/core/vm/state/impl/state_tree_impl.cpp
+++ b/core/vm/state/impl/state_tree_impl.cpp
@@ -37,8 +37,9 @@ namespace fc::vm::state {
       return address;
     }
     OUTCOME_TRY(init_actor, get(actor::kInitAddress));
-    OUTCOME_TRY(init_actor_state,
-                store_->getCbor<actor::InitActorState>(init_actor.head));
+    OUTCOME_TRY(
+        init_actor_state,
+        store_->getCbor<actor::init_actor::InitActorState>(init_actor.head));
     Hamt address_map(store_, init_actor_state.address_map);
     OUTCOME_TRY(id, address_map.getCbor<uint64_t>(encodeToString(address)));
     return Address::makeFromId(id);
@@ -47,8 +48,9 @@ namespace fc::vm::state {
   outcome::result<Address> StateTreeImpl::registerNewAddress(
       const Address &address, const Actor &actor) {
     OUTCOME_TRY(init_actor, get(actor::kInitAddress));
-    OUTCOME_TRY(init_actor_state,
-                store_->getCbor<actor::InitActorState>(init_actor.head));
+    OUTCOME_TRY(
+        init_actor_state,
+        store_->getCbor<actor::init_actor::InitActorState>(init_actor.head));
     OUTCOME_TRY(address_id, init_actor_state.addActor(store_, address));
     OUTCOME_TRY(init_actor_state_cid, store_->setCbor(init_actor_state));
     init_actor.head = ActorSubstateCID{init_actor_state_cid};

--- a/test/core/vm/actor/CMakeLists.txt
+++ b/test/core/vm/actor/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(init_actor_test
     actor
     hexutil
     ipfs_datastore_in_memory
+    runtime
+    state_tree
     )
 
 addtest(cron_actor_test

--- a/test/core/vm/actor/cron_actor_test.cpp
+++ b/test/core/vm/actor/cron_actor_test.cpp
@@ -28,8 +28,8 @@ TEST(CronActorTest, WrongSender) {
   actor::Actor actor;
   EXPECT_CALL(runtime, getMessage())
       .WillOnce(testing::Return(message_wrong_sender));
-  EXPECT_OUTCOME_FALSE(err, actor::CronActor::epochTick(actor, runtime, {}));
-  ASSERT_EQ(err, actor::CronActor::WRONG_CALL);
+  EXPECT_OUTCOME_FALSE(err, actor::cron_actor::epochTick(actor, runtime, {}));
+  ASSERT_EQ(err, actor::cron_actor::WRONG_CALL);
 }
 
 /**
@@ -48,5 +48,5 @@ TEST(CronActorTest, Correct) {
                    MethodParams{},
                    actor::BigInt(0)))
       .WillOnce(testing::Return(fc::outcome::success()));
-  EXPECT_OUTCOME_TRUE_1(actor::CronActor::epochTick(actor, runtime, {}));
+  EXPECT_OUTCOME_TRUE_1(actor::cron_actor::epochTick(actor, runtime, {}));
 }

--- a/test/core/vm/actor/cron_actor_test.cpp
+++ b/test/core/vm/actor/cron_actor_test.cpp
@@ -22,8 +22,8 @@ using fc::vm::runtime::MockRuntime;
  * @then error WRONG_CALL
  */
 TEST(CronActorTest, WrongSender) {
-  auto message_wrong_sender = std::make_shared<UnsignedMessage>(
-      UnsignedMessage{actor::kInitAddress, actor::kInitAddress});
+  auto message_wrong_sender =
+      UnsignedMessage{actor::kInitAddress, actor::kInitAddress};
   MockRuntime runtime;
   actor::Actor actor;
   EXPECT_CALL(runtime, getMessage())
@@ -38,8 +38,7 @@ TEST(CronActorTest, WrongSender) {
  * @then success
  */
 TEST(CronActorTest, Correct) {
-  auto message = std::make_shared<UnsignedMessage>(
-      UnsignedMessage{actor::kInitAddress, actor::kCronAddress});
+  auto message = UnsignedMessage{actor::kInitAddress, actor::kCronAddress};
   MockRuntime runtime;
   actor::Actor actor;
   EXPECT_CALL(runtime, getMessage()).WillOnce(testing::Return(message));

--- a/test/core/vm/actor/init_actor_test.cpp
+++ b/test/core/vm/actor/init_actor_test.cpp
@@ -119,11 +119,12 @@ TEST(InitActorExecText, ExecSuccess) {
                    message.value))
       .WillOnce(testing::Return(fc::outcome::success()));
 
-  EXPECT_CALL(runtime, getHead()).WillOnce(testing::Return(init_actor.head));
+  EXPECT_CALL(runtime, getCurrentActorState())
+      .WillOnce(testing::Return(init_actor.head));
 
   EXPECT_CALL(runtime, commit(testing::_))
-      .WillOnce(testing::Invoke([&](auto new_head) {
-        init_actor.head = new_head;
+      .WillOnce(testing::Invoke([&](auto new_state) {
+        init_actor.head = new_state;
         return state_tree->set(kInitAddress, init_actor);
       }));
 

--- a/test/core/vm/actor/init_actor_test.cpp
+++ b/test/core/vm/actor/init_actor_test.cpp
@@ -14,17 +14,18 @@
 #include "testutil/init_actor.hpp"
 #include "testutil/mocks/vm/runtime/runtime_mock.hpp"
 
+namespace InitActor = fc::vm::actor::init_actor;
+
 using fc::primitives::BigInt;
 using fc::primitives::address::Address;
 using fc::vm::actor::CodeId;
-using fc::vm::actor::InitActor;
-using fc::vm::actor::InitActorState;
 using fc::vm::actor::InvocationOutput;
 using fc::vm::actor::kInitAddress;
 using fc::vm::actor::MethodNumber;
 using fc::vm::actor::MethodParams;
 using fc::vm::message::UnsignedMessage;
 using fc::vm::runtime::MockRuntime;
+using InitActor::InitActorState;
 
 /** Init actor state CBOR encoding and decoding */
 TEST(InitActorTest, InitActorStateCbor) {

--- a/test/core/vm/actor/invoker_test.cpp
+++ b/test/core/vm/actor/invoker_test.cpp
@@ -19,8 +19,7 @@ using fc::vm::runtime::MockRuntime;
 TEST(InvokerTest, InvokeCron) {
   using namespace fc::vm::actor;
 
-  auto message = std::make_shared<UnsignedMessage>(
-      UnsignedMessage{kInitAddress, kInitAddress});
+  auto message = UnsignedMessage{kInitAddress, kInitAddress};
   InvokerImpl invoker;
   MockRuntime runtime;
 
@@ -36,7 +35,8 @@ TEST(InvokerTest, InvokeCron) {
   EXPECT_CALL(runtime, getMessage()).WillOnce(testing::Return(message));
   EXPECT_OUTCOME_ERROR(
       CronActor::WRONG_CALL,
-      invoker.invoke({kCronCodeCid}, runtime, CronActor::kEpochTickMethodNumber, {}));
+      invoker.invoke(
+          {kCronCodeCid}, runtime, CronActor::kEpochTickMethodNumber, {}));
 }
 
 /// decodeActorParams returns error or decoded params

--- a/test/core/vm/actor/invoker_test.cpp
+++ b/test/core/vm/actor/invoker_test.cpp
@@ -36,7 +36,7 @@ TEST(InvokerTest, InvokeCron) {
   EXPECT_CALL(runtime, getMessage()).WillOnce(testing::Return(message));
   EXPECT_OUTCOME_ERROR(
       CronActor::WRONG_CALL,
-      invoker.invoke({kCronCodeCid}, runtime, MethodNumber{2}, {}));
+      invoker.invoke({kCronCodeCid}, runtime, CronActor::kEpochTickMethodNumber, {}));
 }
 
 /// decodeActorParams returns error or decoded params

--- a/test/core/vm/actor/invoker_test.cpp
+++ b/test/core/vm/actor/invoker_test.cpp
@@ -34,9 +34,9 @@ TEST(InvokerTest, InvokeCron) {
       invoker.invoke({kCronCodeCid}, runtime, MethodNumber{1000}, {}));
   EXPECT_CALL(runtime, getMessage()).WillOnce(testing::Return(message));
   EXPECT_OUTCOME_ERROR(
-      CronActor::WRONG_CALL,
+      cron_actor::WRONG_CALL,
       invoker.invoke(
-          {kCronCodeCid}, runtime, CronActor::kEpochTickMethodNumber, {}));
+          {kCronCodeCid}, runtime, cron_actor::kEpochTickMethodNumber, {}));
 }
 
 /// decodeActorParams returns error or decoded params

--- a/test/core/vm/runtime/runtime_test.cpp
+++ b/test/core/vm/runtime/runtime_test.cpp
@@ -235,8 +235,8 @@ TEST_F(RuntimeTest, sendNotEnoughFunds) {
  * @then State is updated
  */
 TEST_F(RuntimeTest, Commit) {
-  auto new_head = ActorSubstateCID{"010001020002"_cid};
-  EXPECT_NE(runtime_->getHead(), new_head);
-  EXPECT_OUTCOME_TRUE_1(runtime_->commit(new_head));
-  EXPECT_EQ(runtime_->getHead(), new_head);
+  auto new_state = ActorSubstateCID{"010001020002"_cid};
+  EXPECT_NE(runtime_->getCurrentActorState(), new_state);
+  EXPECT_OUTCOME_TRUE_1(runtime_->commit(new_state));
+  EXPECT_EQ(runtime_->getCurrentActorState(), new_state);
 }

--- a/test/core/vm/runtime/runtime_test.cpp
+++ b/test/core/vm/runtime/runtime_test.cpp
@@ -137,13 +137,14 @@ TEST_F(RuntimeTest, createActorValid) {
       fc::vm::actor::kInitCodeCid, ActorSubstateCID{}, 0, 0};
   CodeId new_code{fc::vm::actor::kEmptyObjectCid};
   Address new_address{fc::primitives::address::TESTNET, 2};
+  Actor actor{new_code, ActorSubstateCID{fc::vm::actor::kEmptyObjectCid}, 0, 0};
 
   EXPECT_CALL(*state_tree_, get(Eq(immediate_caller_)))
       .WillOnce(testing::Return(fc::outcome::success(immediate_caller_actor)));
-  EXPECT_CALL(*state_tree_, registerNewAddress(Eq(new_address), _))
-      .WillOnce(testing::Return(fc::outcome::success(new_address)));
+  EXPECT_CALL(*state_tree_, set(Eq(new_address), Eq(actor)))
+      .WillOnce(testing::Return(fc::outcome::success()));
 
-  EXPECT_OUTCOME_TRUE_1(runtime_->createActor(new_code, new_address));
+  EXPECT_OUTCOME_TRUE_1(runtime_->createActor(new_address, actor));
 }
 
 /**
@@ -162,7 +163,7 @@ TEST_F(RuntimeTest, createActorNotPermitted) {
       .WillOnce(testing::Return(fc::outcome::success(immediate_caller_actor)));
 
   EXPECT_OUTCOME_ERROR(RuntimeError::CREATE_ACTOR_OPERATION_NOT_PERMITTED,
-                       runtime_->createActor(new_code, new_address));
+                       runtime_->createActor(new_address, {}));
 }
 
 /**

--- a/test/core/vm/runtime/runtime_test.cpp
+++ b/test/core/vm/runtime/runtime_test.cpp
@@ -11,6 +11,7 @@
 #include "crypto/randomness/randomness_types.hpp"
 #include "primitives/address/address.hpp"
 #include "primitives/big_int.hpp"
+#include "testutil/cbor.hpp"
 #include "testutil/mocks/crypto/randomness/randomness_provider_mock.hpp"
 #include "testutil/mocks/storage/ipfs/ipfs_datastore_mock.hpp"
 #include "testutil/mocks/vm/actor/invoker_mock.hpp"
@@ -78,7 +79,9 @@ class RuntimeTest : public ::testing::Test {
                                     immediate_caller_,
                                     block_miner_,
                                     gas_available_,
-                                    gas_used_);
+                                    gas_used_,
+                                    ActorSubstateCID{"010001020001"_cid}
+                                    );
 };
 
 /**
@@ -225,4 +228,11 @@ TEST_F(RuntimeTest, sendNotEnoughFunds) {
 
   EXPECT_OUTCOME_ERROR(RuntimeError::NOT_ENOUGH_FUNDS,
                        runtime_->send(to_address, method, params, amount));
+}
+
+TEST_F(RuntimeTest, Commit) {
+  auto new_head = ActorSubstateCID{"010001020002"_cid};
+  EXPECT_NE(runtime_->getHead(), new_head);
+  EXPECT_OUTCOME_TRUE_1(runtime_->commit(new_head));
+  EXPECT_EQ(runtime_->getHead(), new_head);
 }

--- a/test/testutil/init_actor.hpp
+++ b/test/testutil/init_actor.hpp
@@ -17,8 +17,9 @@ std::shared_ptr<fc::vm::state::StateTree> setupInitActor(
   }
   auto store = state_tree->getStore();
   EXPECT_OUTCOME_TRUE(empty_map, fc::storage::hamt::Hamt(store).flush());
-  EXPECT_OUTCOME_TRUE(
-      state, store->setCbor(fc::vm::actor::InitActorState{empty_map, next_id}));
+  EXPECT_OUTCOME_TRUE(state,
+                      store->setCbor(fc::vm::actor::init_actor::InitActorState{
+                          empty_map, next_id}));
   EXPECT_OUTCOME_TRUE_1(state_tree->set(fc::vm::actor::kInitAddress,
                                         {fc::vm::actor::kInitCodeCid,
                                          fc::vm::actor::ActorSubstateCID{state},

--- a/test/testutil/mocks/vm/runtime/runtime_mock.hpp
+++ b/test/testutil/mocks/vm/runtime/runtime_mock.hpp
@@ -55,7 +55,7 @@ namespace fc::vm::runtime {
 
     MOCK_METHOD0(getIpfsDatastore, std::shared_ptr<IpfsDatastore>());
 
-    MOCK_METHOD0(getMessage, std::shared_ptr<UnsignedMessage>());
+    MOCK_METHOD0(getMessage, std::reference_wrapper<const UnsignedMessage>());
 
     MOCK_METHOD1(chargeGas, outcome::result<void>(const BigInt &amount));
 

--- a/test/testutil/mocks/vm/runtime/runtime_mock.hpp
+++ b/test/testutil/mocks/vm/runtime/runtime_mock.hpp
@@ -59,10 +59,10 @@ namespace fc::vm::runtime {
 
     MOCK_METHOD1(chargeGas, outcome::result<void>(const BigInt &amount));
 
-    MOCK_METHOD0(getHead, ActorSubstateCID());
+    MOCK_METHOD0(getCurrentActorState, ActorSubstateCID());
 
     MOCK_METHOD1(commit,
-                 outcome::result<void>(const ActorSubstateCID &new_head));
+                 outcome::result<void>(const ActorSubstateCID &new_state));
   };
 }  // namespace fc::vm::runtime
 

--- a/test/testutil/mocks/vm/runtime/runtime_mock.hpp
+++ b/test/testutil/mocks/vm/runtime/runtime_mock.hpp
@@ -48,7 +48,8 @@ namespace fc::vm::runtime {
     MOCK_METHOD0(createNewActorAddress, Address());
 
     MOCK_METHOD2(createActor,
-                 outcome::result<void>(CodeId code_id, const Address &address));
+                 outcome::result<void>(const Address &address,
+                                       const Actor &actor));
 
     MOCK_METHOD1(deleteActor, outcome::result<void>(const Address &address));
 

--- a/test/testutil/mocks/vm/runtime/runtime_mock.hpp
+++ b/test/testutil/mocks/vm/runtime/runtime_mock.hpp
@@ -56,6 +56,13 @@ namespace fc::vm::runtime {
     MOCK_METHOD0(getIpfsDatastore, std::shared_ptr<IpfsDatastore>());
 
     MOCK_METHOD0(getMessage, std::shared_ptr<UnsignedMessage>());
+
+    MOCK_METHOD1(chargeGas, outcome::result<void>(const BigInt &amount));
+
+    MOCK_METHOD0(getHead, ActorSubstateCID());
+
+    MOCK_METHOD1(commit,
+                 outcome::result<void>(const ActorSubstateCID &new_head));
   };
 }  // namespace fc::vm::runtime
 


### PR DESCRIPTION
### Description of the Change
Add `InitActor::exec`.
Add `Address::makeActorExecAddress`.
Add `Runtime.chargeGas`, `Runtime.getHead`, `Runtime.commit`.
Change `Runtime.createActor`, `Runtime.getMessage`.

### Benefits
`InitActor` `Exec` VM method

### Possible Drawbacks 
None