### PR TITLE
Remove UBigInt

### DIFF
--- a/core/power/power_table.hpp
+++ b/core/power/power_table.hpp
@@ -13,7 +13,7 @@
 namespace fc::power {
 
   using primitives::address::Address;
-  using Power = primitives::UBigInt;
+  using Power = primitives::BigInt;
 
   /**
    * @interface Provides an interface to the power table

--- a/core/primitives/big_int.hpp
+++ b/core/primitives/big_int.hpp
@@ -8,168 +8,35 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
-#include "codec/cbor/cbor.hpp"
+#include "codec/cbor/streams_annotation.hpp"
 
 namespace fc::primitives {
-  using boost::multiprecision::cpp_int;
+  using BigInt = boost::multiprecision::cpp_int;
+}  // namespace fc::primitives
 
-  struct UBigInt : cpp_int,
-                   boost::totally_ordered<UBigInt>,
-                   boost::arithmetic<UBigInt>,
-                   boost::totally_ordered<UBigInt, int> {
-    using cpp_int::cpp_int;
-
-    inline bool operator==(int other) const {
-      return static_cast<cpp_int>(*this) == other;
-    }
-
-    inline bool operator==(const UBigInt &other) const {
-      return static_cast<cpp_int>(*this) == static_cast<cpp_int>(other);
-    }
-
-    inline bool operator<(int other) const {
-      return static_cast<cpp_int>(*this) < other;
-    }
-
-    inline bool operator<(const UBigInt &other) const {
-      return static_cast<cpp_int>(*this) < static_cast<cpp_int>(other);
-    }
-
-    inline UBigInt operator+=(const UBigInt &other) {
-      *static_cast<cpp_int *>(this) += static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline UBigInt operator-=(const UBigInt &other) {
-      *static_cast<cpp_int *>(this) -= static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline UBigInt operator*=(const UBigInt &other) {
-      *static_cast<cpp_int *>(this) *= static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline UBigInt operator/=(const UBigInt &other) {
-      *static_cast<cpp_int *>(this) /= static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    template <typename Integral>
-    inline UBigInt operator+(Integral other) const {
-      return static_cast<cpp_int>(*this) + static_cast<cpp_int>(other);
-    }
-
-    inline UBigInt operator-(int other) const {
-      return static_cast<cpp_int>(*this) - other;
-    }
-  };
-
-  struct BigInt : cpp_int,
-                  boost::totally_ordered<BigInt>,
-                  boost::totally_ordered<BigInt, int>,
-                  boost::arithmetic<BigInt>,
-                  boost::multiplicative<BigInt, unsigned long>,
-                  boost::less_than_comparable<BigInt, UBigInt>,
-                  boost::multipliable<BigInt, UBigInt> {
-    using cpp_int::cpp_int;
-
-    inline bool operator==(int other) const {
-      return static_cast<cpp_int>(*this) == other;
-    }
-
-    inline bool operator<(int other) const {
-      return static_cast<cpp_int>(*this) < other;
-    }
-
-    inline bool operator==(const BigInt &other) const {
-      return static_cast<cpp_int>(*this) == static_cast<cpp_int>(other);
-    }
-
-    inline bool operator<(const BigInt &other) const {
-      return static_cast<cpp_int>(*this) < static_cast<cpp_int>(other);
-    }
-
-    inline BigInt operator+=(const BigInt &other) {
-      *static_cast<cpp_int *>(this) += static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline BigInt operator-=(const BigInt &other) {
-      *static_cast<cpp_int *>(this) -= static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline BigInt operator*=(const BigInt &other) {
-      *static_cast<cpp_int *>(this) *= static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline BigInt operator/=(const BigInt &other) {
-      *static_cast<cpp_int *>(this) /= static_cast<cpp_int>(other);
-      return *this;
-    }
-
-    inline BigInt operator*=(const unsigned long &other) {
-      *static_cast<cpp_int *>(this) *= other;
-      return *this;
-    }
-
-    inline BigInt operator/=(const unsigned long &other) {
-      *static_cast<cpp_int *>(this) /= other;
-      return *this;
-    }
-
-    inline bool operator<(const UBigInt &other) const {
-      return static_cast<cpp_int>(*this) < static_cast<cpp_int>(other);
-    }
-
-    inline bool operator>(const UBigInt &other) const {
-      return static_cast<cpp_int>(*this) > static_cast<cpp_int>(other);
-    }
-
-    inline BigInt operator*=(const UBigInt &other) {
-      *static_cast<cpp_int *>(this) *= static_cast<cpp_int>(other);
-      return *this;
-    }
-  };
-
-  template <class Stream,
-            class T,
-            typename = std::enable_if_t<
-                (std::is_same_v<T, BigInt> || std::is_same_v<T, UBigInt>)&&std::
-                    remove_reference<Stream>::type::is_cbor_encoder_stream>>
-  Stream &operator<<(Stream &&s, const T &big_int) {
+namespace boost::multiprecision {
+  CBOR_ENCODE(cpp_int, big_int) {
     std::vector<uint8_t> bytes;
     if (big_int != 0) {
-      if (std::is_same_v<T, BigInt>) {
-        bytes.push_back(big_int < 0 ? 1 : 0);
-      }
+      bytes.push_back(big_int < 0 ? 1 : 0);
       export_bits(big_int, std::back_inserter(bytes), 8);
     }
     return s << bytes;
   }
 
-  template <class Stream,
-            class T,
-            typename = std::enable_if_t<
-                (std::is_same_v<T, BigInt> || std::is_same_v<T, UBigInt>)&&std::
-                    remove_reference_t<Stream>::is_cbor_decoder_stream>>
-  Stream &operator>>(Stream &&s, T &big_int) {
+  CBOR_DECODE(cpp_int, big_int) {
     std::vector<uint8_t> bytes;
     s >> bytes;
     if (bytes.empty()) {
       big_int = 0;
     } else {
-      import_bits(big_int,
-                  bytes.begin() + (std::is_same_v<T, BigInt> ? 1 : 0),
-                  bytes.end());
-      if (std::is_same_v<T, BigInt> && bytes[0] == 1) {
+      import_bits(big_int, bytes.begin() + 1, bytes.end());
+      if (bytes[0] == 1) {
         big_int = -big_int;
       }
     }
     return s;
   }
-}  // namespace fc::primitives
+}  // namespace boost::multiprecision
 
 #endif  // CPP_FILECOIN_CORE_PRIMITIVES_BIG_INT_HPP

--- a/core/primitives/chain_epoch.hpp
+++ b/core/primitives/chain_epoch.hpp
@@ -14,7 +14,7 @@ namespace fc::primitives {
    * @brief epoch index type represents a round of a blockchain protocol, which
    * acts as a proxy for time within the VM
    */
-  using ChainEpoch = UBigInt;
+  using ChainEpoch = BigInt;
 
   using EpochDuration = BigInt;
 

--- a/core/vm/actor/builtin/payment_channel/payment_channel_actor_state.hpp
+++ b/core/vm/actor/builtin/payment_channel/payment_channel_actor_state.hpp
@@ -20,7 +20,6 @@ namespace fc::vm::actor::builtin::payment_channel {
   using fc::vm::actor::MethodNumber;
   using primitives::BigInt;
   using primitives::ChainEpoch;
-  using primitives::UBigInt;
   using primitives::address::Address;
 
   struct LaneState {
@@ -37,7 +36,7 @@ namespace fc::vm::actor::builtin::payment_channel {
   struct PaymentChannelActorState {
     Address from;
     Address to;
-    UBigInt to_send{};
+    BigInt to_send{};
     ChainEpoch settling_at;
     ChainEpoch min_settling_height;
     std::vector<LaneState> lanes{};
@@ -63,7 +62,7 @@ namespace fc::vm::actor::builtin::payment_channel {
     ModularVerificationParameter extra;
     uint64_t lane{};
     uint64_t nonce{};
-    UBigInt amount;
+    BigInt amount;
     uint64_t min_close_height{};
     std::vector<Merge> merges{};
     Signature signature;

--- a/test/core/codec/cbor/cbor_test.cpp
+++ b/test/core/codec/cbor/cbor_test.cpp
@@ -57,15 +57,6 @@ TEST(Cbor, BigInt) {
   EXPECT_OUTCOME_EQ(decode<BigInt>("40"_unhex), 0);
 }
 
-/** UBigInt CBOR encoding and decoding */
-TEST(Cbor, UBigInt) {
-  using fc::primitives::UBigInt;
-  EXPECT_OUTCOME_EQ(encode(UBigInt(0xCAFE)), "42CAFE"_unhex);
-  EXPECT_OUTCOME_EQ(decode<UBigInt>("42CAFE"_unhex), 0xCAFE);
-  EXPECT_OUTCOME_EQ(encode(UBigInt(0)), "40"_unhex);
-  EXPECT_OUTCOME_EQ(decode<UBigInt>("40"_unhex), 0);
-}
-
 /** Null CBOR encoding and decoding */
 TEST(Cbor, Null) {
   EXPECT_OUTCOME_EQ(encode(nullptr), "F6"_unhex);

--- a/test/core/primitives/big_int_test.cpp
+++ b/test/core/primitives/big_int_test.cpp
@@ -47,5 +47,5 @@ TEST(BigInt, Divide) {
 TEST(BigInt, DivideByZero) {
   BigInt a{8};
   BigInt b{0};
-  ASSERT_THROW(a / b, std::exception);
+  ASSERT_THROW(BigInt{a / b}, std::exception);
 }

--- a/test/core/primitives/tipset/tipset_key_test.cpp
+++ b/test/core/primitives/tipset/tipset_key_test.cpp
@@ -50,7 +50,6 @@ TEST_F(TipsetKeyTest, DISABLED_ToPrettyStringSuccess) {
  * @then the representation meets lotus-calculated value
  */
 TEST_F(TipsetKeyTest, ToBytesSuccess) {
-  EXPECT_OUTCOME_TRUE(vec1, key1.toBytes());
   EXPECT_OUTCOME_TRUE(vec2, key2.toBytes());
   EXPECT_OUTCOME_TRUE(vec3, key3.toBytes());
   EXPECT_OUTCOME_TRUE(vec4, key4.toBytes());


### PR DESCRIPTION
### Description of the Change
Remove `UBigInt`.
Make `BigInt` an alias of `boost::multiprecision::cpp_int`.

### Benefits
`UBigInt` is used by HAMT and misused by everyone else.
`UBigInt` and `BigInt` introduced ambiguity in operators.

### Possible Drawbacks 
None