### PR TITLE
Refactor cbor tuple

### DIFF
--- a/core/codec/cbor/cbor_decode_stream.hpp
+++ b/core/codec/cbor/cbor_decode_stream.hpp
@@ -22,7 +22,9 @@ namespace fc::codec::cbor {
     explicit CborDecodeStream(gsl::span<const uint8_t> data);
 
     /** Decodes integer or bool */
-    template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+    template <
+        typename T,
+        typename = std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>>
     CborDecodeStream &operator>>(T &num) {
       if constexpr (std::is_same_v<T, bool>) {
         if (!cbor_value_is_boolean(&value_)) {

--- a/core/codec/cbor/cbor_encode_stream.hpp
+++ b/core/codec/cbor/cbor_encode_stream.hpp
@@ -20,15 +20,17 @@ namespace fc::codec::cbor {
     static constexpr auto is_cbor_encoder_stream = true;
 
     /** Encodes integer or bool */
-    template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+    template <
+        typename T,
+        typename = std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>>
     CborEncodeStream &operator<<(T num) {
       addCount(1);
       std::array<uint8_t, 9> buffer{0};
       CborEncoder encoder;
       cbor_encoder_init(&encoder, buffer.data(), buffer.size(), 0);
-      if (std::is_same_v<T, bool>) {
+      if constexpr (std::is_same_v<T, bool>) {
         cbor_encode_boolean(&encoder, num);
-      } else if (std::is_unsigned_v<T>) {
+      } else if constexpr (std::is_unsigned_v<T>) {
         cbor_encode_uint(&encoder, static_cast<uint64_t>(num));
       } else {
         cbor_encode_int(&encoder, static_cast<int64_t>(num));

--- a/core/codec/cbor/streams_annotation.hpp
+++ b/core/codec/cbor/streams_annotation.hpp
@@ -18,4 +18,61 @@
                 std::remove_reference_t<Stream>::is_cbor_decoder_stream>> \
   Stream &operator>>(Stream &&s, type &var)
 
+#define _CBOR_TUPLE_1(op, m) op t.m
+#define _CBOR_TUPLE_2(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_1(op, __VA_ARGS__)
+#define _CBOR_TUPLE_3(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_2(op, __VA_ARGS__)
+#define _CBOR_TUPLE_4(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_3(op, __VA_ARGS__)
+#define _CBOR_TUPLE_5(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_4(op, __VA_ARGS__)
+#define _CBOR_TUPLE_6(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_5(op, __VA_ARGS__)
+#define _CBOR_TUPLE_7(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_6(op, __VA_ARGS__)
+#define _CBOR_TUPLE_8(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_7(op, __VA_ARGS__)
+#define _CBOR_TUPLE_9(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_8(op, __VA_ARGS__)
+#define _CBOR_TUPLE_10(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_9(op, __VA_ARGS__)
+#define _CBOR_TUPLE_11(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_10(op, __VA_ARGS__)
+#define _CBOR_TUPLE_12(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_11(op, __VA_ARGS__)
+#define _CBOR_TUPLE_13(op, m, ...) \
+  _CBOR_TUPLE_1(op, m) _CBOR_TUPLE_12(op, __VA_ARGS__)
+#define _CBOR_TUPLE_V(                                              \
+    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, f, ...) \
+  f
+#define _CBOR_TUPLE(op, ...)    \
+  _CBOR_TUPLE_V(__VA_ARGS__,    \
+                _CBOR_TUPLE_13, \
+                _CBOR_TUPLE_12, \
+                _CBOR_TUPLE_11, \
+                _CBOR_TUPLE_10, \
+                _CBOR_TUPLE_9,  \
+                _CBOR_TUPLE_8,  \
+                _CBOR_TUPLE_7,  \
+                _CBOR_TUPLE_6,  \
+                _CBOR_TUPLE_5,  \
+                _CBOR_TUPLE_4,  \
+                _CBOR_TUPLE_3,  \
+                _CBOR_TUPLE_2,  \
+                _CBOR_TUPLE_1)  \
+  (op, __VA_ARGS__)
+
+#define CBOR_ENCODE_TUPLE(T, ...)                        \
+  CBOR_ENCODE(T, t) {                                    \
+    return s << (s.list() _CBOR_TUPLE(<<, __VA_ARGS__)); \
+  }
+
+#define CBOR_TUPLE(T, ...)                 \
+  CBOR_ENCODE_TUPLE(T, __VA_ARGS__)        \
+  CBOR_DECODE(T, t) {                      \
+    s.list() _CBOR_TUPLE(>>, __VA_ARGS__); \
+    return s;                              \
+  }
+
 #endif  // CPP_FILECOIN_STREAMS_ANNOTATION_HPP

--- a/core/crypto/randomness/impl/randomness_provider_impl.cpp
+++ b/core/crypto/randomness/impl/randomness_provider_impl.cpp
@@ -21,7 +21,7 @@ namespace fc::crypto::randomness {
                                                       Serialization s,
                                                       const ChainEpoch &index) {
     return deriveRandomnessInternal(
-        static_cast<uint64_t>(tag), std::move(s), index.convert_to<int64_t>());
+        static_cast<uint64_t>(tag), std::move(s), index);
   }
 
   Randomness RandomnessProviderImpl::deriveRandomnessInternal(uint64_t tag,

--- a/core/primitives/address/address_codec.hpp
+++ b/core/primitives/address/address_codec.hpp
@@ -53,11 +53,8 @@ namespace fc::primitives::address {
   CBOR_DECODE(Address, address) {
     std::vector<uint8_t> data{};
     s >> data;
-    auto res = decode(data);
-    if (res.has_error()) {
-      outcome::raise(AddressError::INVALID_PAYLOAD);
-    }
-    address = std::move(res.value());
+    OUTCOME_EXCEPT(decoded, decode(data));
+    address = std::move(decoded);
     return s;
   }
 

--- a/core/primitives/block/block.hpp
+++ b/core/primitives/block/block.hpp
@@ -57,30 +57,20 @@ namespace fc::primitives::block {
            && lhs.fork_signaling == rhs.fork_signaling;
   }
 
-  CBOR_ENCODE(BlockHeader, block) {
-    return s << (s.list() << block.miner << block.ticket << block.epost_proof
-                          << block.parents << block.parent_weight
-                          << block.height << block.parent_state_root
-                          << block.parent_message_receipts << block.messages
-                          << block.bls_aggregate << block.timestamp
-                          << block.block_sig << block.fork_signaling);
-  }
+  CBOR_TUPLE(BlockHeader,
+             miner,
+             ticket,
+             epost_proof,
+             parents,
+             parent_weight,
+             height,
+             parent_state_root,
+             parent_message_receipts,
+             messages,
+             bls_aggregate,
+             timestamp,
+             block_sig,
+             fork_signaling)
 
-  CBOR_DECODE(BlockHeader, block) {
-    s.list() >> block.miner >> block.ticket >> block.epost_proof
-        >> block.parents >> block.parent_weight >> block.height
-        >> block.parent_state_root >> block.parent_message_receipts
-        >> block.messages >> block.bls_aggregate >> block.timestamp
-        >> block.block_sig >> block.fork_signaling;
-    return s;
-  }
-
-  CBOR_ENCODE(MsgMeta, meta) {
-    return s << (s.list() << meta.bls_messages << meta.secpk_messages);
-  }
-
-  CBOR_DECODE(MsgMeta, meta) {
-    s.list() >> meta.bls_messages >> meta.secpk_messages;
-    return s;
-  }
+  CBOR_TUPLE(MsgMeta, bls_messages, secpk_messages)
 }  // namespace fc::primitives::block

--- a/core/primitives/chain_epoch/chain_epoch.hpp
+++ b/core/primitives/chain_epoch/chain_epoch.hpp
@@ -14,9 +14,11 @@ namespace fc::primitives {
    * @brief epoch index type represents a round of a blockchain protocol, which
    * acts as a proxy for time within the VM
    */
-  using ChainEpoch = BigInt;
+  using ChainEpoch = int64_t;
 
-  using EpochDuration = BigInt;
+  using EpochDuration = int64_t;
+
+  constexpr ChainEpoch kChainEpochUndefined{-1};
 
 }  // namespace fc::primitives
 

--- a/core/primitives/chain_epoch/chain_epoch_codec.cpp
+++ b/core/primitives/chain_epoch/chain_epoch_codec.cpp
@@ -13,7 +13,7 @@ namespace fc::primitives::chain_epoch {
 
   std::string encodeToByteString(const ChainEpoch &epoch) {
     // TODO (a.chernyshov) actor-specs uses Protobuf Varint encoding
-    UVarint number(epoch.convert_to<int64_t>());
+    UVarint number(epoch);
     auto encoded = number.toBytes();
     return std::string(encoded.begin(), encoded.end());
   }

--- a/core/primitives/ticket/epost_ticket_codec.hpp
+++ b/core/primitives/ticket/epost_ticket_codec.hpp
@@ -23,17 +23,7 @@ namespace fc::primitives::ticket {
 OUTCOME_HPP_DECLARE_ERROR(fc::primitives::ticket, EPoSTTicketCodecError)
 
 namespace fc::primitives::ticket {
-  /**
-   * @brief cbor-encode EPostTicket instance
-   * @tparam Stream cbor-encoder stream type
-   * @param s stream reference
-   * @param ticket Ticket const reference to encode
-   * @return stream reference
-   */
-  CBOR_ENCODE(EPostTicket, ticket) {
-    return s << (s.list() << ticket.partial << ticket.sector_id
-                          << ticket.challenge_index);
-  }
+  CBOR_ENCODE_TUPLE(EPostTicket, partial, sector_id, challenge_index)
 
   /**
    * @brief cbor-decode EPostTicket instance
@@ -52,16 +42,7 @@ namespace fc::primitives::ticket {
     return s;
   }
 
-  /**
-   * @brief cbor-encodes EPostProof instance
-   * @tparam Stream cbor-encoder stream type
-   * @param s stream reference
-   * @param epp EPostProof const reference to encode
-   * @return stream reference
-   */
-  CBOR_ENCODE(EPostProof, epp) {
-    return s << (s.list() << epp.proof << epp.post_rand << epp.candidates);
-  }
+  CBOR_ENCODE_TUPLE(EPostProof, proof, post_rand, candidates)
 
   /**
    * @brief cbor-decodes EPostProof instance

--- a/core/primitives/ticket/ticket_codec.hpp
+++ b/core/primitives/ticket/ticket_codec.hpp
@@ -14,8 +14,8 @@
 #include "primitives/ticket/ticket.hpp"
 
 namespace fc::primitives::ticket {
-  enum class TicketCodecError: int {
-    INVALID_TICKET_LENGTH = 1, // ticket decode error, invalid data length
+  enum class TicketCodecError : int {
+    INVALID_TICKET_LENGTH = 1,  // ticket decode error, invalid data length
   };
 }  // namespace fc::primitives::ticket
 
@@ -29,9 +29,7 @@ namespace fc::primitives::ticket {
    * @param ticket Ticket const reference to encode
    * @return stream reference
    */
-  CBOR_ENCODE(Ticket, ticket) {
-    return s << (s.list() << ticket.bytes);
-  }
+  CBOR_ENCODE_TUPLE(Ticket, bytes)
 
   /**
    * @brief cbor-decodes Ticket instance
@@ -52,4 +50,4 @@ namespace fc::primitives::ticket {
 
 }  // namespace fc::primitives::ticket
 
-#endif  //CPP_FILECOIN_CORE_PRIMITIVES_TICKET_TICKET_CODEC_HPP
+#endif  // CPP_FILECOIN_CORE_PRIMITIVES_TICKET_TICKET_CODEC_HPP

--- a/core/primitives/tipset/tipset.hpp
+++ b/core/primitives/tipset/tipset.hpp
@@ -88,34 +88,7 @@ namespace fc::primitives::tipset {
 
   bool operator==(const Tipset &lhs, const Tipset &rhs);
 
-  /**
-   * @brief cbor-encodes Tipset instance
-   * @tparam Stream cbor-encoder stream type
-   * @param s stream reference
-   * @param tipset Tipset instance
-   * @return stream reference
-   */
-  CBOR_ENCODE(Tipset, tipset) {
-    return s << (s.list() << tipset.cids << tipset.blks << tipset.height);
-  }
-
-  /**
-   * @brief cbor-decodes Tipset instance
-   * @tparam Stream cbor-decoder stream type
-   * @param s stream reference
-   * @param tipset Tipset instance reference to decode into
-   * @return stream reference
-   */
-  CBOR_DECODE(Tipset, tipset) {
-    std::vector<CID> cids;
-    std::vector<block::BlockHeader> blks;
-
-    s.list() >> cids >> blks >> tipset.height;
-    tipset.cids = std::move(cids);
-    tipset.blks = std::move(blks);
-    return s;
-  }
-
+  CBOR_TUPLE(Tipset, cids, blks, height)
 }  // namespace fc::primitives::tipset
 
 #endif  // CPP_FILECOIN_CORE_PRIMITIVES_TIPSET_TIPSET_HPP

--- a/core/storage/amt/amt.hpp
+++ b/core/storage/amt/amt.hpp
@@ -123,14 +123,7 @@ namespace fc::storage::amt {
     Node node;
   };
 
-  CBOR_ENCODE(Root, root) {
-    return s << (s.list() << root.height << root.count << root.node);
-  }
-
-  CBOR_DECODE(Root, root) {
-    s.list() >> root.height >> root.count >> root.node;
-    return s;
-  }
+  CBOR_TUPLE(Root, height, count, node)
 
   class Amt {
    public:

--- a/core/vm/actor/actor.hpp
+++ b/core/vm/actor/actor.hpp
@@ -99,15 +99,7 @@ namespace fc::vm::actor {
 
   bool operator==(const Actor &lhs, const Actor &rhs);
 
-  CBOR_ENCODE(Actor, actor) {
-    return s << (s.list() << actor.code << actor.head << actor.nonce
-                          << actor.balance);
-  }
-
-  CBOR_DECODE(Actor, actor) {
-    s.list() >> actor.code >> actor.head >> actor.nonce >> actor.balance;
-    return s;
-  }
+  CBOR_TUPLE(Actor, code, head, nonce, balance)
 
   /** Check if code specifies builtin actor implementation */
   bool isBuiltinActor(const CodeId &code);

--- a/core/vm/actor/builtin/account/account_actor.hpp
+++ b/core/vm/actor/builtin/account/account_actor.hpp
@@ -35,14 +35,7 @@ namespace fc::vm::actor::builtin::account {
         const std::shared_ptr<StateTree> &state_tree, const Address &address);
   };
 
-  CBOR_ENCODE(AccountActorState, state) {
-    return s << (s.list() << state.address);
-  }
-
-  CBOR_DECODE(AccountActorState, state) {
-    s.list() >> state.address;
-    return s;
-  }
+  CBOR_TUPLE(AccountActorState, address)
 
 }  // namespace fc::vm::actor::builtin::account
 

--- a/core/vm/actor/builtin/init/init_actor.hpp
+++ b/core/vm/actor/builtin/init/init_actor.hpp
@@ -24,14 +24,7 @@ namespace fc::vm::actor::builtin::init {
     uint64_t next_id{};
   };
 
-  CBOR_ENCODE(InitActorState, state) {
-    return s << (s.list() << state.address_map << state.next_id);
-  }
-
-  CBOR_DECODE(InitActorState, state) {
-    s.list() >> state.address_map >> state.next_id;
-    return s;
-  }
+  CBOR_TUPLE(InitActorState, address_map, next_id)
 
   constexpr MethodNumber kExecMethodNumber{2};
 
@@ -46,14 +39,7 @@ namespace fc::vm::actor::builtin::init {
 
   extern const ActorExports exports;
 
-  CBOR_ENCODE(ExecParams, params) {
-    return s << (s.list() << params.code << params.params);
-  }
-
-  CBOR_DECODE(ExecParams, params) {
-    s.list() >> params.code >> params.params;
-    return s;
-  }
+  CBOR_TUPLE(ExecParams, code, params)
 }  // namespace fc::vm::actor::builtin::init
 
 #endif  // CPP_FILECOIN_CORE_VM_ACTOR_INIT_ACTOR_HPP

--- a/core/vm/actor/builtin/miner/types.hpp
+++ b/core/vm/actor/builtin/miner/types.hpp
@@ -18,7 +18,9 @@ namespace fc::vm::actor::builtin::miner {
   using primitives::BigInt;
   using primitives::RleBitset;
   using primitives::address::Address;
-  using proofs::Comm;
+  using proofs::Proof;
+
+  using PeerId = std::string;
 
   struct PoStState {
     uint64_t proving_period_start;
@@ -57,7 +59,7 @@ namespace fc::vm::actor::builtin::miner {
     Address owner;
     Address worker;
     boost::optional<WorkerKeyChange> pending_worker_key;
-    std::string peer_id;
+    PeerId peer_id;
     uint64_t sector_size;
   };
 
@@ -70,83 +72,35 @@ namespace fc::vm::actor::builtin::miner {
     PoStState post_state;
   };
 
-  CBOR_ENCODE(PoStState, state) {
-    return s << (s.list() << state.proving_period_start
-                          << state.num_consecutive_failures);
-  }
+  CBOR_TUPLE(PoStState, proving_period_start, num_consecutive_failures)
 
-  CBOR_DECODE(PoStState, state) {
-    s.list() >> state.proving_period_start >> state.num_consecutive_failures;
-    return s;
-  }
+  CBOR_TUPLE(
+      SectorPreCommitInfo, sector, sealed_cid, seal_epoch, deal_ids, expiration)
 
-  CBOR_ENCODE(SectorPreCommitInfo, info) {
-    return s << (s.list() << info.sector << info.sealed_cid << info.seal_epoch
-                          << info.deal_ids << info.expiration);
-  }
+  CBOR_TUPLE(SectorPreCommitOnChainInfo,
+             info,
+             precommit_deposit,
+             precommit_epoch)
 
-  CBOR_DECODE(SectorPreCommitInfo, info) {
-    s.list() >> info.sector >> info.sealed_cid >> info.seal_epoch
-        >> info.deal_ids >> info.expiration;
-    return s;
-  }
+  CBOR_TUPLE(SectorOnChainInfo,
+             info,
+             activation_epoch,
+             deal_weight,
+             pledge_requirement,
+             declared_fault_epoch,
+             declared_fault_duration)
 
-  CBOR_ENCODE(SectorPreCommitOnChainInfo, info) {
-    return s << (s.list() << info.info << info.precommit_deposit
-                          << info.precommit_epoch);
-  }
+  CBOR_TUPLE(WorkerKeyChange, new_worker, effective_at)
 
-  CBOR_DECODE(SectorPreCommitOnChainInfo, info) {
-    s.list() >> info.info >> info.precommit_deposit >> info.precommit_epoch;
-    return s;
-  }
+  CBOR_TUPLE(MinerInfo, owner, worker, pending_worker_key, peer_id, sector_size)
 
-  CBOR_ENCODE(SectorOnChainInfo, info) {
-    return s << (s.list() << info.info << info.activation_epoch
-                          << info.deal_weight << info.pledge_requirement
-                          << info.declared_fault_epoch
-                          << info.declared_fault_duration);
-  }
-
-  CBOR_DECODE(SectorOnChainInfo, info) {
-    s.list() >> info.info >> info.activation_epoch >> info.deal_weight
-        >> info.pledge_requirement >> info.declared_fault_epoch
-        >> info.declared_fault_duration;
-    return s;
-  }
-
-  CBOR_ENCODE(WorkerKeyChange, change) {
-    return s << (s.list() << change.new_worker << change.effective_at);
-  }
-
-  CBOR_DECODE(WorkerKeyChange, change) {
-    s.list() >> change.new_worker >> change.effective_at;
-    return s;
-  }
-
-  CBOR_ENCODE(MinerInfo, info) {
-    return s << (s.list() << info.owner << info.worker
-                          << info.pending_worker_key << info.peer_id
-                          << info.sector_size);
-  }
-
-  CBOR_DECODE(MinerInfo, info) {
-    s.list() >> info.owner >> info.worker >> info.pending_worker_key
-        >> info.peer_id >> info.sector_size;
-    return s;
-  }
-
-  CBOR_ENCODE(MinerActorState, state) {
-    return s << (s.list() << state.precommitted_sectors << state.sectors
-                          << state.fault_set << state.proving_set << state.info
-                          << state.post_state);
-  }
-
-  CBOR_DECODE(MinerActorState, state) {
-    s.list() >> state.precommitted_sectors >> state.sectors >> state.fault_set
-        >> state.proving_set >> state.info >> state.post_state;
-    return s;
-  }
+  CBOR_TUPLE(MinerActorState,
+             precommitted_sectors,
+             sectors,
+             fault_set,
+             proving_set,
+             info,
+             post_state)
 }  // namespace fc::vm::actor::builtin::miner
 
 #endif  // CPP_FILECOIN_CORE_VM_ACTOR_BUILTIN_MINER_TYPES_HPP

--- a/core/vm/actor/builtin/miner/types.hpp
+++ b/core/vm/actor/builtin/miner/types.hpp
@@ -16,6 +16,7 @@
 namespace fc::vm::actor::builtin::miner {
   using libp2p::multi::UVarint;
   using primitives::BigInt;
+  using primitives::ChainEpoch;
   using primitives::RleBitset;
   using primitives::address::Address;
   using proofs::Proof;

--- a/core/vm/actor/builtin/miner/types.hpp
+++ b/core/vm/actor/builtin/miner/types.hpp
@@ -30,24 +30,24 @@ namespace fc::vm::actor::builtin::miner {
   struct SectorPreCommitInfo {
     uint64_t sector;
     CID sealed_cid;
-    uint64_t seal_epoch;
+    ChainEpoch seal_epoch;
     std::vector<uint64_t> deal_ids;
-    uint64_t expiration;
+    ChainEpoch expiration;
   };
 
   struct SectorPreCommitOnChainInfo {
     SectorPreCommitInfo info;
     BigInt precommit_deposit;
-    uint64_t precommit_epoch;
+    ChainEpoch precommit_epoch;
   };
 
   struct SectorOnChainInfo {
     SectorPreCommitInfo info;
-    uint64_t activation_epoch;
+    ChainEpoch activation_epoch;
     BigInt deal_weight;
     BigInt pledge_requirement;
-    uint64_t declared_fault_epoch;
-    uint64_t declared_fault_duration;
+    ChainEpoch declared_fault_epoch;
+    ChainEpoch declared_fault_duration;
   };
 
   struct WorkerKeyChange {

--- a/core/vm/actor/builtin/multisig/multisig_actor.hpp
+++ b/core/vm/actor/builtin/multisig/multisig_actor.hpp
@@ -219,154 +219,36 @@ namespace fc::vm::actor::builtin::multisig {
   /** Exported Multisig Actor methods to invoker */
   extern const ActorExports exports;
 
-  /**
-   * CBOR serialization of MultiSignatureTransaction
-   */
-  CBOR_ENCODE(MultiSignatureTransaction, transaction) {
-    return s << (s.list() << transaction.transaction_number << transaction.to
-                          << transaction.value << transaction.method
-                          << transaction.params << transaction.approved);
-  }
+  CBOR_TUPLE(MultiSignatureTransaction,
+             transaction_number,
+             to,
+             value,
+             method,
+             params,
+             approved)
 
-  /**
-   * CBOR deserialization of MultiSignatureTransaction
-   */
-  CBOR_DECODE(MultiSignatureTransaction, transaction) {
-    s.list() >> transaction.transaction_number >> transaction.to
-        >> transaction.value >> transaction.method >> transaction.params
-        >> transaction.approved;
-    return s;
-  }
+  CBOR_TUPLE(MultiSignatureActorState,
+             signers,
+             threshold,
+             next_transaction_id,
+             initial_balance,
+             start_epoch,
+             unlock_duration,
+             pending_transactions)
 
-  /**
-   * CBOR serialization of MultiSignatureActorState
-   */
-  CBOR_ENCODE(MultiSignatureActorState, state) {
-    return s << (s.list() << state.signers << state.threshold
-                          << state.next_transaction_id << state.initial_balance
-                          << state.start_epoch << state.unlock_duration
-                          << state.pending_transactions);
-  }
+  CBOR_TUPLE(ConstructParameters, signers, threshold, unlock_duration)
 
-  /**
-   * CBOR deserialization of MultiSignatureActorState
-   */
-  CBOR_DECODE(MultiSignatureActorState, state) {
-    s.list() >> state.signers >> state.threshold >> state.next_transaction_id
-        >> state.initial_balance >> state.start_epoch >> state.unlock_duration
-        >> state.pending_transactions;
-    return s;
-  }
+  CBOR_TUPLE(ProposeParameters, to, value, method, params)
 
-  /**
-   * CBOR serialization of ConstructParameters
-   */
-  CBOR_ENCODE(ConstructParameters, construct_params) {
-    return s << (s.list() << construct_params.signers
-                          << construct_params.threshold
-                          << construct_params.unlock_duration);
-  }
+  CBOR_TUPLE(TransactionNumberParameters, transaction_number)
 
-  /**
-   * CBOR deserialization of ConstructParameters
-   */
-  CBOR_DECODE(ConstructParameters, construct_params) {
-    s.list() >> construct_params.signers >> construct_params.threshold
-        >> construct_params.unlock_duration;
-    return s;
-  }
+  CBOR_TUPLE(AddSignerParameters, signer, increase_threshold)
 
-  /**
-   * CBOR serialization of ProposeParameters
-   */
-  CBOR_ENCODE(ProposeParameters, propose_params) {
-    return s << (s.list() << propose_params.to << propose_params.value
-                          << propose_params.method << propose_params.params);
-  }
+  CBOR_TUPLE(RemoveSignerParameters, signer, decrease_threshold)
 
-  /**
-   * CBOR deserialization of ProposeParameters
-   */
-  CBOR_DECODE(ProposeParameters, propose_params) {
-    s.list() >> propose_params.to >> propose_params.value
-        >> propose_params.method >> propose_params.params;
-    return s;
-  }
+  CBOR_TUPLE(SwapSignerParameters, old_signer, new_signer)
 
-  /**
-   * CBOR serialization of TransactionNumberParameters
-   */
-  CBOR_ENCODE(TransactionNumberParameters, params) {
-    return s << (s.list() << params.transaction_number);
-  }
-
-  /**
-   * CBOR deserialization of TransactionNumberParameters
-   */
-  CBOR_DECODE(TransactionNumberParameters, params) {
-    s.list() >> params.transaction_number;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of AddSignerParameters
-   */
-  CBOR_ENCODE(AddSignerParameters, params) {
-    return s << (s.list() << params.signer << params.increase_threshold);
-  }
-
-  /**
-   * CBOR deserialization of AddSignerParameters
-   */
-  CBOR_DECODE(AddSignerParameters, params) {
-    s.list() >> params.signer >> params.increase_threshold;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of RemoveSignerParameters
-   */
-  CBOR_ENCODE(RemoveSignerParameters, params) {
-    return s << (s.list() << params.signer << params.decrease_threshold);
-  }
-
-  /**
-   * CBOR deserialization of RemoveSignerParameters
-   */
-  CBOR_DECODE(RemoveSignerParameters, params) {
-    s.list() >> params.signer >> params.decrease_threshold;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of SwapSignerParameters
-   */
-  CBOR_ENCODE(SwapSignerParameters, params) {
-    return s << (s.list() << params.old_signer << params.new_signer);
-  }
-
-  /**
-   * CBOR deserialization of SwapSignerParameters
-   */
-  CBOR_DECODE(SwapSignerParameters, params) {
-    s.list() >> params.old_signer >> params.new_signer;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of ChangeThresholdParameters
-   */
-  CBOR_ENCODE(ChangeThresholdParameters, params) {
-    return s << (s.list() << params.new_threshold);
-  }
-
-  /**
-   * CBOR deserialization of ChangeThresholdParameters
-   */
-  CBOR_DECODE(ChangeThresholdParameters, params) {
-    s.list() >> params.new_threshold;
-    return s;
-  }
+  CBOR_TUPLE(ChangeThresholdParameters, new_threshold)
 
 }  // namespace fc::vm::actor::builtin::multisig
 

--- a/core/vm/actor/builtin/payment_channel/payment_channel_actor.hpp
+++ b/core/vm/actor/builtin/payment_channel/payment_channel_actor.hpp
@@ -51,36 +51,9 @@ namespace fc::vm::actor::builtin::payment_channel {
         const Actor &actor, Runtime &runtime, const MethodParams &params);
   };
 
-  /**
-   * CBOR serialization of ConstructParameteres
-   */
-  CBOR_ENCODE(ConstructParameteres, construct_params) {
-    return s << (s.list() << construct_params.to);
-  }
+  CBOR_TUPLE(ConstructParameteres, to)
 
-  /**
-   * CBOR deserialization of ConstructParameteres
-   */
-  CBOR_DECODE(ConstructParameteres, construct_params) {
-    s.list() >> construct_params.to;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of UpdateChannelStateParameters
-   */
-  CBOR_ENCODE(UpdateChannelStateParameters, params) {
-    return s << (s.list() << params.signed_voucher << params.secret
-                          << params.proof);
-  }
-
-  /**
-   * CBOR deserialization of UpdateChannelStateParameters
-   */
-  CBOR_DECODE(UpdateChannelStateParameters, params) {
-    s.list() >> params.signed_voucher >> params.secret >> params.proof;
-    return s;
-  }
+  CBOR_TUPLE(UpdateChannelStateParameters, signed_voucher, secret, proof)
 
 }  // namespace fc::vm::actor::builtin::payment_channel
 

--- a/core/vm/actor/builtin/payment_channel/payment_channel_actor_state.hpp
+++ b/core/vm/actor/builtin/payment_channel/payment_channel_actor_state.hpp
@@ -69,88 +69,30 @@ namespace fc::vm::actor::builtin::payment_channel {
     Signature signature;
   };
 
-  /**
-   * CBOR serialization of LaneState
-   */
-  CBOR_ENCODE(LaneState, state) {
-    return s << (s.list() << state.state << state.redeem << state.nonce);
-  }
+  CBOR_TUPLE(LaneState, state, redeem, nonce)
 
-  /**
-   * CBOR deserialization of LaneState
-   */
-  CBOR_DECODE(LaneState, state) {
-    s.list() >> state.state >> state.redeem >> state.nonce;
-    return s;
-  }
+  CBOR_TUPLE(PaymentChannelActorState,
+             from,
+             to,
+             to_send,
+             settling_at,
+             min_settling_height,
+             lanes)
 
-  /**
-   * CBOR serialization of PaymentChannelActorState
-   */
-  CBOR_ENCODE(PaymentChannelActorState, state) {
-    return s << (s.list() << state.from << state.to << state.to_send
-                          << state.settling_at << state.min_settling_height
-                          << state.lanes);
-  }
+  CBOR_TUPLE(ModularVerificationParameter, actor, method, data)
 
-  /**
-   * CBOR deserialization of PaymentChannelActorState
-   */
-  CBOR_DECODE(PaymentChannelActorState, state) {
-    s.list() >> state.from >> state.to >> state.to_send >> state.settling_at
-        >> state.min_settling_height >> state.lanes;
-    return s;
-  }
+  CBOR_TUPLE(Merge, lane, nonce)
 
-  /**
-   * CBOR serialization of ModularVerificationParameter
-   */
-  CBOR_ENCODE(ModularVerificationParameter, param) {
-    return s << (s.list() << param.actor << param.method << param.data);
-  }
-
-  /**
-   * CBOR deserialization of ModularVerificationParameter
-   */
-  CBOR_DECODE(ModularVerificationParameter, param) {
-    s.list() >> param.actor >> param.method >> param.data;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of Merge
-   */
-  CBOR_ENCODE(Merge, merge) {
-    return s << (s.list() << merge.lane << merge.nonce);
-  }
-
-  /**
-   * CBOR deserialization of Merge
-   */
-  CBOR_DECODE(Merge, merge) {
-    s.list() >> merge.lane >> merge.nonce;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of SignedVoucher
-   */
-  CBOR_ENCODE(SignedVoucher, voucher) {
-    return s << (s.list() << voucher.time_lock << voucher.secret_preimage
-                          << voucher.extra << voucher.lane << voucher.nonce
-                          << voucher.amount << voucher.min_close_height
-                          << voucher.merges << voucher.signature);
-  }
-
-  /**
-   * CBOR deserialization of SignedVoucher
-   */
-  CBOR_DECODE(SignedVoucher, voucher) {
-    s.list() >> voucher.time_lock >> voucher.secret_preimage >> voucher.extra
-        >> voucher.lane >> voucher.nonce >> voucher.amount
-        >> voucher.min_close_height >> voucher.merges >> voucher.signature;
-    return s;
-  }
+  CBOR_TUPLE(SignedVoucher,
+             time_lock,
+             secret_preimage,
+             extra,
+             lane,
+             nonce,
+             amount,
+             min_close_height,
+             merges,
+             signature)
 
 }  // namespace fc::vm::actor::builtin::payment_channel
 #endif  // CPP_FILECOIN_VM_ACTOR_BUILTIN_PAYMENT_CHANNEL_ACTOR_STATE_HPP

--- a/core/vm/actor/builtin/reward/reward_actor.hpp
+++ b/core/vm/actor/builtin/reward/reward_actor.hpp
@@ -39,18 +39,16 @@ namespace fc::vm::actor::builtin::reward {
   };
 
   CBOR_ENCODE(Reward, reward) {
-    return s << (s.list() << common::to_int(reward.vesting_function)
+    return s << (s.list() << reward.vesting_function
                           << reward.start_epoch.convert_to<uint64_t>()
                           << reward.end_epoch.convert_to<uint64_t>()
                           << reward.value << reward.amount_withdrawn);
   }
 
   CBOR_DECODE(Reward, reward) {
-    uint64_t vesting_function_value, start_epoch, end_epoch;
-    s.list() >> vesting_function_value >> start_epoch >> end_epoch
+    uint64_t start_epoch, end_epoch;
+    s.list() >> reward.vesting_function >> start_epoch >> end_epoch
         >> reward.value >> reward.amount_withdrawn;
-    reward.vesting_function =
-        static_cast<VestingFunction>(vesting_function_value);
     reward.start_epoch = start_epoch;
     reward.end_epoch = end_epoch;
     return s;

--- a/core/vm/actor/builtin/reward/reward_actor.hpp
+++ b/core/vm/actor/builtin/reward/reward_actor.hpp
@@ -38,21 +38,8 @@ namespace fc::vm::actor::builtin::reward {
         const primitives::ChainEpoch &current_epoch);
   };
 
-  CBOR_ENCODE(Reward, reward) {
-    return s << (s.list() << reward.vesting_function
-                          << reward.start_epoch.convert_to<uint64_t>()
-                          << reward.end_epoch.convert_to<uint64_t>()
-                          << reward.value << reward.amount_withdrawn);
-  }
-
-  CBOR_DECODE(Reward, reward) {
-    uint64_t start_epoch, end_epoch;
-    s.list() >> reward.vesting_function >> start_epoch >> end_epoch
-        >> reward.value >> reward.amount_withdrawn;
-    reward.start_epoch = start_epoch;
-    reward.end_epoch = end_epoch;
-    return s;
-  }
+  CBOR_TUPLE(
+      Reward, vesting_function, start_epoch, end_epoch, value, amount_withdrawn)
 
   struct State {
     TokenAmount reward_total;

--- a/core/vm/actor/builtin/reward/reward_actor.hpp
+++ b/core/vm/actor/builtin/reward/reward_actor.hpp
@@ -71,14 +71,7 @@ namespace fc::vm::actor::builtin::reward {
         const primitives::ChainEpoch &current_epoch);
   };
 
-  CBOR_ENCODE(State, state) {
-    return s << (s.list() << state.reward_map << state.reward_total);
-  }
-
-  CBOR_DECODE(State, state) {
-    s.list() >> state.reward_map >> state.reward_total;
-    return s;
-  }
+  CBOR_TUPLE(State, reward_map, reward_total)
 
   // Actor related stuff
 
@@ -95,17 +88,7 @@ namespace fc::vm::actor::builtin::reward {
     Power nominal_power;
   };
 
-  CBOR_ENCODE(AwardBlockRewardParams, v) {
-    return s << (s.list() << v.miner << v.penalty << v.gas_reward
-                          << v.nominal_power.convert_to<BigInt>());
-  }
-
-  CBOR_DECODE(AwardBlockRewardParams, v) {
-    BigInt power;
-    s.list() >> v.miner >> v.penalty >> v.gas_reward >> power;
-    v.nominal_power = power.convert_to<decltype(v.nominal_power)>();
-    return s;
-  }
+  CBOR_TUPLE(AwardBlockRewardParams, miner, penalty, gas_reward, nominal_power)
 
   constexpr MethodNumber kAwardBlockRewardMethodNumber{2};
   constexpr MethodNumber kWithdrawRewardMethodNumber{3};

--- a/core/vm/actor/builtin/storage_power/storage_power_actor_state.hpp
+++ b/core/vm/actor/builtin/storage_power/storage_power_actor_state.hpp
@@ -259,47 +259,18 @@ namespace fc::vm::actor::builtin::storage_power {
     std::shared_ptr<Hamt> claims_;
   };
 
-  /**
-   * CBOR serialization of Claim
-   */
-  CBOR_ENCODE(Claim, claim) {
-    return s << (s.list() << claim.power << claim.pledge);
-  }
+  CBOR_TUPLE(Claim, power, pledge)
 
-  /**
-   * CBOR deserialization of Claim
-   */
-  CBOR_DECODE(Claim, claim) {
-    s.list() >> claim.power >> claim.pledge;
-    return s;
-  }
+  CBOR_TUPLE(CronEvent, miner_address, callback_payload)
 
-  /**
-   * CBOR serialization of CronEvent
-   */
-  CBOR_ENCODE(CronEvent, event) {
-    return s << (s.list() << event.miner_address << event.callback_payload);
-  }
-
-  /**
-   * CBOR deserialization of CronEvent
-   */
-  CBOR_DECODE(CronEvent, event) {
-    s.list() >> event.miner_address >> event.callback_payload;
-    return s;
-  }
-
-  /**
-   * CBOR serialization of StoragePowerActorState
-   */
-  CBOR_ENCODE(StoragePowerActorState, state) {
-    return s << (s.list() << state.total_network_power << state.miner_count
-                          << state.escrow_table->root
-                          << state.cron_event_queue_cid
-                          << state.po_st_detected_fault_miners_cid
-                          << state.claims_cid
-                          << state.num_miners_meeting_min_power);
-  }
+  CBOR_ENCODE_TUPLE(StoragePowerActorState,
+                    total_network_power,
+                    miner_count,
+                    escrow_table->root,
+                    cron_event_queue_cid,
+                    po_st_detected_fault_miners_cid,
+                    claims_cid,
+                    num_miners_meeting_min_power)
 
   /**
    * CBOR deserialization of ChangeThresholdParameters

--- a/core/vm/message/message_codec.hpp
+++ b/core/vm/message/message_codec.hpp
@@ -13,27 +13,17 @@
 #include "vm/message/message.hpp"
 
 namespace fc::vm::message {
+  CBOR_TUPLE(UnsignedMessage,
+             to,
+             from,
+             nonce,
+             value,
+             gasPrice,
+             gasLimit,
+             method,
+             params)
 
-  CBOR_ENCODE(UnsignedMessage, m) {
-    return s << (s.list() << m.to << m.from << m.nonce << m.value << m.gasPrice
-                          << m.gasLimit << m.method << m.params);
-  }
-
-  CBOR_DECODE(UnsignedMessage, m) {
-    s.list() >> m.to >> m.from >> m.nonce >> m.value >> m.gasPrice >> m.gasLimit
-        >> m.method >> m.params;
-    return s;
-  }
-
-  CBOR_ENCODE(SignedMessage, sm) {
-    return s << (s.list() << sm.message << sm.signature);
-  }
-
-  CBOR_DECODE(SignedMessage, sm) {
-    s.list() >> sm.message >> sm.signature;
-    return s;
-  }
-
+  CBOR_TUPLE(SignedMessage, message, signature)
 };  // namespace fc::vm::message
 
 #endif  // CPP_FILECOIN_CORE_VM_MESSAGE_CODEC_HPP

--- a/core/vm/runtime/runtime_types.hpp
+++ b/core/vm/runtime/runtime_types.hpp
@@ -44,15 +44,7 @@ namespace fc::vm::runtime {
     BigInt gas_used;
   };
 
-  CBOR_ENCODE(MessageReceipt, receipt) {
-    return s << (s.list() << receipt.exit_code << receipt.return_value
-                          << receipt.gas_used);
-  }
-
-  CBOR_DECODE(MessageReceipt, receipt) {
-    return s << (s.list() << receipt.exit_code << receipt.return_value
-                          << receipt.gas_used);
-  }
+  CBOR_TUPLE(MessageReceipt, exit_code, return_value, gas_used)
 }  // namespace fc::vm::runtime
 
 #endif  // CPP_FILECOIN_CORE_VM_RUNTIME_RUNTIME_TYPES_HPP


### PR DESCRIPTION
### Description of the Change
Added `CBOR_TUPLE` macro to generate simple cbor encoders/decoders.
Changed `ChainEpoch` to `int64_t`.

### Benefits
Less code for most cbor encoders/decoders.

### Possible Drawbacks 
None