### PR TITLE
Cross compiling fixes, improvements and additions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,18 +34,8 @@ endif ()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(CheckCXXCompilerFlag)
-include(cmake/toolchain-util.cmake)
-include(cmake/dependencies.cmake)
-include(cmake/functions.cmake)
-include(cmake/san.cmake)
-
 # export compile commands for clang-tidy to analyse only changed files
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-print("C flags: ${CMAKE_C_FLAGS}")
-print("CXX flags: ${CMAKE_CXX_FLAGS}")
-print("Using CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
 
 option(TESTING "Build tests" ON)
 option(TESTING_PROOFS "Build proofs tests" OFF)
@@ -60,6 +50,15 @@ option(MSAN "Enable memory sanitizer" OFF)
 option(TSAN "Enable thread sanitizer" OFF)
 option(UBSAN "Enable UB sanitizer" OFF)
 
+include(CheckCXXCompilerFlag)
+include(cmake/toolchain-util.cmake)
+include(cmake/dependencies.cmake)
+include(cmake/functions.cmake)
+include(cmake/san.cmake)
+
+print("C flags: ${CMAKE_C_FLAGS}")
+print("CXX flags: ${CMAKE_CXX_FLAGS}")
+print("Using CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
 
 ## setup compilation flags
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(TESTING "Build tests" ON)
 option(TESTING_PROOFS "Build proofs tests" OFF)
 option(TESTING_ACTORS "Build actors tests" OFF)
+option(BUILD_INTERNAL_DEPS "Build internal dependencies from git submodules" ON)
 option(CLANG_FORMAT "Enable clang-format target" ON)
 option(CLANG_TIDY "Enable clang-tidy checks during compilation" OFF)
 option(COVERAGE "Enable generation of coverage info" OFF)
@@ -102,7 +103,9 @@ if (CLANG_FORMAT)
   include(cmake/clang-format.cmake)
 endif ()
 
-add_subdirectory(deps)
+if (BUILD_INTERNAL_DEPS)
+  add_subdirectory(deps)
+endif()
 
 include_directories(
     # project includes
@@ -110,12 +113,14 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/libs
 )
 
-include_directories(
-    SYSTEM
-    # system includes
-    deps/indicators/include
-    deps/libsecp256k1/include
-)
+if (BUILD_INTERNAL_DEPS)
+  include_directories(
+      SYSTEM
+      # system includes
+      deps/indicators/include
+      deps/libsecp256k1/include
+  )
+endif()
 
 add_subdirectory(libs)
 add_subdirectory(core)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,9 +1,11 @@
 # hunter dependencies
 # https://docs.hunter.sh/en/latest/packages/
 
-# https://docs.hunter.sh/en/latest/packages/pkg/GTest.html
-hunter_add_package(GTest)
-find_package(GTest CONFIG REQUIRED)
+if (TESTING)
+  # https://docs.hunter.sh/en/latest/packages/pkg/GTest.html
+  hunter_add_package(GTest)
+  find_package(GTest CONFIG REQUIRED)
+endif()
 
 hunter_add_package(libarchive)
 find_package(libarchive CONFIG REQUIRED)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -50,9 +50,6 @@ find_package(leveldb CONFIG REQUIRED)
 hunter_add_package(libp2p)
 find_package(libp2p CONFIG REQUIRED)
 
-hunter_add_package(c-ares)
-find_package(c-ares CONFIG REQUIRED)
-
 hunter_add_package(soralog)
 find_package(soralog CONFIG REQUIRED)
 

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -46,8 +46,13 @@ function(add_flag flag)
 endfunction()
 
 function(compile_proto_to_cpp PB_H PB_CC PROTO)
-  get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc IMPORTED_LOCATION_RELEASE)
+  if (NOT Protobuf_INCLUDE_DIR)
+    get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+  if (NOT Protobuf_PROTOC_EXECUTABLE)
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc IMPORTED_LOCATION_RELEASE)
+    set(PROTOBUF_DEPENDS protobuf::protoc)
+  endif()
 
   if (NOT Protobuf_PROTOC_EXECUTABLE)
     message(FATAL_ERROR "Protobuf_PROTOC_EXECUTABLE is empty")
@@ -73,7 +78,7 @@ function(compile_proto_to_cpp PB_H PB_CC PROTO)
       COMMAND ${GEN_COMMAND}
       ARGS -I${PROJECT_SOURCE_DIR}/core -I${GEN_ARGS} -I${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${SCHEMA_OUT_DIR} ${PROTO_ABS}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-      DEPENDS protobuf::protoc
+      DEPENDS ${PROTOBUF_DEPENDS}
       VERBATIM
   )
 


### PR DESCRIPTION
## Description of the Change

This PR contains the build system fixes, improvements and additions broken out from https://github.com/filecoin-project/cpp-filecoin/pull/114.

### Structure of the PR

The PR is organized as follows:

1. Fixes needed for cross-compiling
2. Improvements needed for cross-compiling

### Fixes for cross-compiling

Commits:

- ~~CMake: Fix error including generated protobuf headers~~
- ~~Fix tinycbor include directory~~

These commits come first, because they address what could be considered defects. Inclusion would be valuable even if the rest of the PR is omitted. Further description is in the commit message.

### Changes for cross-compiling

Commits:

- [CMake: Expose CMake options to includes](https://github.com/eigendude/cpp-filecoin/commit/cross-compile-fixes~4)
- [CMake: Exclude test-related depends when building tests](https://github.com/eigendude/cpp-filecoin/commit/cross-compile-fixes~3)
- [CMake: Allow excluding git submodule depends](https://github.com/eigendude/cpp-filecoin/commit/cross-compile-fixes~2)

These changes enable more control over the build process when embedded in another build system.

CMake is controlled by user variables; the first one we need is `-DHUNTER_ENABLED=OFF` so that we can have control over dependencies.

Another useful variable is `-DTESTING=OFF`, because embedding test infra drastically increases the up-front effort. The first two commits above allow this variable to exclude test infra from the dependency discovery in addition to the build.

Finally, I introduced a new variable: `-DBUILD_INTERNAL_DEPS=OFF`. This causes the in-tree dependencies to be skipped. I needed this for a build system that doesn't support git submodules. Instead, the dependencies are provided by the build sytsem.

## Dependencies

- [x] https://github.com/soramitsu/libp2p/pull/59 needed for libp2p dependency.

## How has this been tested?

Temporarily disabled proofs and ran `make` from Kodi's build deps. Build succeeds.

Ran `make install`:

```
make[2]: *** No rule to make target 'install'.  Stop.
```

Next PR will address this.
