### PR TITLE
Fix graphsync encoding

### DIFF
--- a/core/adt/address_key.cpp
+++ b/core/adt/address_key.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "adt/address_key.hpp"
+#include "common/span.hpp"
 
 #include "primitives/address/address_codec.hpp"
 
@@ -15,8 +16,6 @@ namespace fc::adt {
 
   outcome::result<AddressKeyer::Key> AddressKeyer::decode(
       const std::string &key) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return primitives::address::decode(gsl::make_span(
-        reinterpret_cast<const uint8_t *>(key.data()), key.size()));
+    return primitives::address::decode(common::span::cbytes(key));
   }
 }  // namespace fc::adt

--- a/core/adt/uvarint_key.cpp
+++ b/core/adt/uvarint_key.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "adt/uvarint_key.hpp"
+#include "common/span.hpp"
 
 #include <libp2p/multi/uvarint.hpp>
 
@@ -26,10 +27,7 @@ namespace fc::adt {
 
   outcome::result<UvarintKeyer::Key> UvarintKeyer::decode(
       const std::string &key) {
-    auto maybe = UVarint::create(gsl::make_span(
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<const uint8_t *>(key.data()),
-        key.size()));
+    auto maybe = UVarint::create(common::span::cbytes(key));
     if (!maybe) {
       return UvarintKeyError::DECODE_ERROR;
     }

--- a/core/codec/uvarint.hpp
+++ b/core/codec/uvarint.hpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CPP_FILECOIN_CODEC_UVARINT_HPP
+#define CPP_FILECOIN_CODEC_UVARINT_HPP
+
+#include <gsl/span>
+#include <libp2p/multi/uvarint.hpp>
+
+#include "common/outcome.hpp"
+
+namespace fc::codec::uvarint {
+  using Input = gsl::span<const uint8_t>;
+
+  template <auto error, typename T = uint64_t>
+  outcome::result<T> read(Input &input) {
+    auto value = libp2p::multi::UVarint::create(input);
+    if (!value) {
+      return error;
+    }
+    input = input.subspan(value->size());
+    return static_cast<T>(value->toUInt64());
+  }
+
+  template <auto error_length, auto error_data>
+  outcome::result<Input> readBytes(Input &input) {
+    OUTCOME_TRY(size, read<error_length>(input));
+    if (input.size() < static_cast<ptrdiff_t>(size)) {
+      return error_data;
+    }
+    auto result = input.subspan(0, size);
+    input = input.subspan(size);
+    return result;
+  }
+}  // namespace fc::codec::uvarint
+
+#endif  // CPP_FILECOIN_CODEC_UVARINT_HPP

--- a/core/common/span.hpp
+++ b/core/common/span.hpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CPP_FILECOIN_CORE_COMMON_SPAN_HPP
+#define CPP_FILECOIN_CORE_COMMON_SPAN_HPP
+
+#include <gsl/span>
+
+namespace fc::common::span {
+  namespace {
+    template <typename To, typename From>
+    constexpr auto cast(gsl::span<From> span) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      return gsl::make_span(reinterpret_cast<To *>(span.data()), span.size());
+    }
+  }  // namespace
+
+  constexpr auto cbytes(gsl::span<const char> span) {
+    return cast<const uint8_t>(span);
+  }
+
+  constexpr auto cstring(gsl::span<const uint8_t> span) {
+    return cast<const char>(span);
+  }
+
+  constexpr auto string(gsl::span<uint8_t> span) {
+    return cast<char>(span);
+  }
+}  // namespace fc::common::span
+
+#endif  // CPP_FILECOIN_CORE_COMMON_SPAN_HPP

--- a/core/common/span.hpp
+++ b/core/common/span.hpp
@@ -9,13 +9,11 @@
 #include <gsl/span>
 
 namespace fc::common::span {
-  namespace {
-    template <typename To, typename From>
-    constexpr auto cast(gsl::span<From> span) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-      return gsl::make_span(reinterpret_cast<To *>(span.data()), span.size());
-    }
-  }  // namespace
+  template <typename To, typename From>
+  constexpr auto cast(gsl::span<From> span) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return gsl::make_span(reinterpret_cast<To *>(span.data()), span.size());
+  }
 
   constexpr auto cbytes(gsl::span<const char> span) {
     return cast<const uint8_t>(span);

--- a/core/primitives/cid/cid.hpp
+++ b/core/primitives/cid/cid.hpp
@@ -60,6 +60,9 @@ namespace fc {
     static outcome::result<CID> fromString(const std::string &str);
 
     static outcome::result<CID> fromBytes(gsl::span<const uint8_t> input);
+
+    static outcome::result<CID> read(gsl::span<const uint8_t> &input,
+                                     bool prefix = false);
   };
 }  // namespace fc
 

--- a/core/storage/car/car.cpp
+++ b/core/storage/car/car.cpp
@@ -5,7 +5,7 @@
 
 #include "storage/car/car.hpp"
 
-#include <libp2p/multi/uvarint.hpp>
+#include "codec/uvarint.hpp"
 
 OUTCOME_CPP_DEFINE_CATEGORY(fc::storage::car, CarError, e) {
   using E = fc::storage::car::CarError;
@@ -16,50 +16,16 @@ OUTCOME_CPP_DEFINE_CATEGORY(fc::storage::car, CarError, e) {
 }
 
 namespace fc::storage::car {
-  using libp2p::multi::UVarint;
-
-  outcome::result<uint64_t> readUvarint(Input &input) {
-    auto value = UVarint::create(input);
-    if (!value) {
-      return CarError::DECODE_ERROR;
-    }
-    input = input.subspan(UVarint::calculateSize(input));
-    return value->toUInt64();
-  }
-
-  outcome::result<Input> readUvarintBytes(Input &input) {
-    OUTCOME_TRY(size, readUvarint(input));
-    if (input.size() < static_cast<ptrdiff_t>(size)) {
-      return CarError::DECODE_ERROR;
-    }
-    auto result = input.subspan(0, size);
-    input = input.subspan(size);
-    return result;
-  }
-
-  outcome::result<CID> readCid(Input &input) {
-    auto input2 = input;
-    if (input.size() >= 2 && input[0] == 12 && input[1] == 32) {
-      if (input.size() < 34) {
-        return CarError::DECODE_ERROR;
-      }
-    } else {
-      OUTCOME_TRY(readUvarint(input));
-      OUTCOME_TRY(readUvarint(input));
-    }
-    OUTCOME_TRY(readUvarint(input));
-    OUTCOME_TRY(readUvarintBytes(input));
-    OUTCOME_TRY(
-        cid, CID::fromBytes(input2.subspan(0, input2.size() - input.size())));
-    return std::move(cid);
-  }
-
   outcome::result<std::vector<CID>> loadCar(Ipld &store, Input input) {
-    OUTCOME_TRY(header_bytes, readUvarintBytes(input));
+    OUTCOME_TRY(header_bytes,
+                codec::uvarint::readBytes<CarError::DECODE_ERROR,
+                                          CarError::DECODE_ERROR>(input));
     OUTCOME_TRY(header, codec::cbor::decode<CarHeader>(header_bytes));
     while (!input.empty()) {
-      OUTCOME_TRY(node, readUvarintBytes(input));
-      OUTCOME_TRY(cid, readCid(node));
+      OUTCOME_TRY(node,
+                  codec::uvarint::readBytes<CarError::DECODE_ERROR,
+                                            CarError::DECODE_ERROR>(input));
+      OUTCOME_TRY(cid, CID::read(node));
       OUTCOME_TRY(store.set(cid, common::Buffer{node}));
     }
     return std::move(header.roots);

--- a/core/storage/ipfs/graphsync/impl/CMakeLists.txt
+++ b/core/storage/ipfs/graphsync/impl/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(graphsync
     cid
     buffer
     cbor
+    filecoin_hasher
     logger
     graphsync_proto
     )

--- a/core/storage/ipfs/graphsync/impl/graphsync_impl.cpp
+++ b/core/storage/ipfs/graphsync/impl/graphsync_impl.cpp
@@ -11,6 +11,8 @@
 #include "network/network.hpp"
 
 namespace fc::storage::ipfs::graphsync {
+  /// Selector that matches current node
+  common::Buffer kSelectorMatcher{0xa1, 0x61, 0x2e, 0xa0};
 
   GraphsyncImpl::GraphsyncImpl(
       std::shared_ptr<libp2p::Host> host,
@@ -63,6 +65,10 @@ namespace fc::storage::ipfs::graphsync {
       logger()->trace("makeRequest: rejecting request to peer {}",
                       peer.toBase58().substr(46));
       return local_requests_->newRejectedRequest(std::move(callback));
+    }
+
+    if (selector.empty()) {
+      selector = kSelectorMatcher;
     }
 
     auto newRequest = local_requests_->newRequest(

--- a/core/storage/ipfs/graphsync/impl/network/marshalling/request_builder.cpp
+++ b/core/storage/ipfs/graphsync/impl/network/marshalling/request_builder.cpp
@@ -22,9 +22,7 @@ namespace fc::storage::ipfs::graphsync {
     auto *dst = pb_msg_->add_requests();
     dst->set_id(request_id);
 
-    CborEncodeStream encoder;
-    encoder << root_cid;
-    auto d = encoder.data();
+    OUTCOME_EXCEPT(d, root_cid.toBytes());
 
     dst->set_root(d.data(), d.size());
     if (!selector.empty()) {

--- a/core/storage/ipfs/graphsync/impl/network/marshalling/response_builder.cpp
+++ b/core/storage/ipfs/graphsync/impl/network/marshalling/response_builder.cpp
@@ -35,10 +35,10 @@ namespace fc::storage::ipfs::graphsync {
                                      const common::Buffer &data) {
     auto *dst = pb_msg_->add_data();
 
-    CborEncodeStream encoder;
-    encoder << cid;
-    auto d = encoder.data();
-    dst->set_prefix(d.data(), d.size());
+    OUTCOME_EXCEPT(d, cid.toBytes());
+    auto prefix_reader = gsl::make_span(std::as_const(d));
+    OUTCOME_EXCEPT(prefix, CID::read(prefix_reader, true));
+    dst->set_prefix(d.data(), d.size() - prefix_reader.size());
     dst->set_data(data.data(), data.size());
     empty_ = false;
   }

--- a/test/core/serialization/serialization_vectors_test.cpp
+++ b/test/core/serialization/serialization_vectors_test.cpp
@@ -10,6 +10,7 @@
 #include <boost/filesystem.hpp>
 
 #include "api/rpc/json.hpp"
+#include "common/span.hpp"
 #include "crypto/bls/impl/bls_provider_impl.hpp"
 #include "storage/keystore/impl/in_memory/in_memory_keystore.hpp"
 #include "testutil/literals.hpp"
@@ -33,7 +34,7 @@ auto loadJson(const std::string &name) {
                           .append(name)
                           .string());
   rapidjson::Document document;
-  document.Parse(reinterpret_cast<const char *>(str.data()), str.size());
+  document.Parse(fc::common::span::cstring(str).data(), str.size());
   EXPECT_FALSE(document.HasParseError());
   return document;
 }

--- a/test/testutil/read_file.hpp
+++ b/test/testutil/read_file.hpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 #include "common/buffer.hpp"
+#include "common/span.hpp"
 
 auto readFile(const std::string &path) {
   std::ifstream file{path, std::ios::binary | std::ios::ate};
@@ -18,7 +19,7 @@ auto readFile(const std::string &path) {
   fc::common::Buffer buffer;
   buffer.resize(file.tellg());
   file.seekg(0, std::ios::beg);
-  file.read(reinterpret_cast<char *>(buffer.data()), buffer.size());
+  file.read(fc::common::span::string(buffer).data(), buffer.size());
   return buffer;
 }
 


### PR DESCRIPTION
### Description of the Change
Extract uvarint and cid "reader" (usual decoder doesn't report byte size).
Fix cid and cid prefix encoding in graphsync messages.
Add default "matcher" selector for graphsync requests.

### Benefits
Graphsync interoperability with lotus.

### Possible Drawbacks 
None