### PR TITLE
Added readPieceFromSealedSector function

### DIFF
--- a/core/primitives/piece/impl/piece_data.cpp
+++ b/core/primitives/piece/impl/piece_data.cpp
@@ -35,4 +35,6 @@ namespace fc::primitives::piece {
     fd_ = other.fd_;
     other.fd_ = kUnopenedFileDescriptor;
   }
+
+  PieceData::PieceData(int pipe_fd) : fd_(pipe_fd) {}
 }  // namespace fc::primitives::piece

--- a/core/primitives/piece/piece_data.hpp
+++ b/core/primitives/piece/piece_data.hpp
@@ -15,6 +15,7 @@ namespace fc::primitives::piece {
   class PieceData {
    public:
     explicit PieceData(const std::string &path_to_file);
+    explicit PieceData(int pipe_fd);
 
     PieceData(PieceData &&other) noexcept;
 

--- a/core/proofs/proofs.hpp
+++ b/core/proofs/proofs.hpp
@@ -206,7 +206,7 @@ namespace fc::proofs {
     /**
      * @brief Unseals the sector at @sealed_path and returns the bytes for a
      * piece whose first (unpadded) byte begins at @offset and ends at @offset
-     * plus @num_bytes, inclusive
+     * plus @length, inclusive
      */
     static outcome::result<void> unsealRange(
         RegisteredProof proof_type,

--- a/core/sector_storage/impl/sector_storage_error.cpp
+++ b/core/sector_storage/impl/sector_storage_error.cpp
@@ -21,6 +21,11 @@ OUTCOME_CPP_DEFINE_CATEGORY(fc::sector_storage, SectorStorageError, e) {
       return "Sector Storage: aggregated piece sizes don't match sector size";
     case (SectorStorageError::CANNOT_CREATE_FILE):
       return "Sector Storage: cannot create a file";
+    case (SectorStorageError::CANNOT_OPEN_FILE):
+      return "Sector Storage: cannot open a file";
+    case (SectorStorageError::OUT_OF_FILE_SIZE):
+      return "Sector Storage: requested piece is out of bound";
+
     default:
       return "Sector Storage: unknown error";
   }

--- a/core/sector_storage/impl/sector_storage_impl.cpp
+++ b/core/sector_storage/impl/sector_storage_impl.cpp
@@ -252,6 +252,8 @@ namespace fc::sector_storage {
       read_size += unsealed_file.gcount();
     }
 
+    delete[] buffer;
+
     close(piece[1]);
 
     unsealed_file.close();

--- a/core/sector_storage/impl/sector_storage_impl.cpp
+++ b/core/sector_storage/impl/sector_storage_impl.cpp
@@ -216,12 +216,12 @@ namespace fc::sector_storage {
                                  unsealedCID));
     }
 
+    if (offset + size > boost::filesystem::file_size(path.unsealed)) {
+      return SectorStorageError::OUT_OF_FILE_SIZE;
+    }
+
     if (size == boost::filesystem::file_size(path.unsealed)) {
-      if (offset == 0) {
-        return PieceData(path.unsealed);
-      } else {
-        return SectorStorageError::OUT_OF_FILE_SIZE;
-      }
+      return PieceData(path.unsealed);
     }
 
     int piece[2];

--- a/core/sector_storage/impl/sector_storage_impl.hpp
+++ b/core/sector_storage/impl/sector_storage_impl.hpp
@@ -21,8 +21,8 @@ namespace fc::sector_storage {
                       RegisteredProof post_proof,
                       RegisteredProof seal_proof);
 
-    outcome::result<SectorPaths> acquireSector(SectorId id,
-                                               SectorFileType sector_type) override;
+    outcome::result<SectorPaths> acquireSector(
+        SectorId id, SectorFileType sector_type) override;
 
     outcome::result<PreCommit1Output> sealPreCommit1(
         const SectorId &sector,
@@ -49,6 +49,13 @@ namespace fc::sector_storage {
         gsl::span<const UnpaddedPieceSize> piece_sizes,
         UnpaddedPieceSize new_piece_size,
         const PieceData &piece_data) override;
+
+    outcome::result<PieceData> readPieceFromSealedSector(
+        const SectorId &sector,
+        UnpaddedByteIndex offset,
+        UnpaddedPieceSize size,
+        const SealRandomness &ticket,
+        const CID &unsealedCID) override;
 
    private:
     path root_;

--- a/core/sector_storage/sector_storage.hpp
+++ b/core/sector_storage/sector_storage.hpp
@@ -14,7 +14,7 @@
 
 namespace fc::sector_storage {
   using fc::primitives::sector_file::SectorPaths;
-
+  using UnpaddedByteIndex = uint64_t;
   using fc::primitives::piece::PieceData;
   using fc::primitives::piece::PieceInfo;
   using fc::primitives::piece::UnpaddedPieceSize;
@@ -55,6 +55,13 @@ namespace fc::sector_storage {
                                                const Commit1Output &c1o) = 0;
 
     virtual outcome::result<void> finalizeSector(const SectorId &sector) = 0;
+
+    virtual outcome::result<PieceData> readPieceFromSealedSector(
+        const SectorId &sector,
+        UnpaddedByteIndex offset,
+        UnpaddedPieceSize size,
+        const SealRandomness &ticket,
+        const CID &unsealedCID) = 0;
 
     // STORAGE
     virtual outcome::result<PieceInfo> addPiece(

--- a/core/sector_storage/sector_storage_error.hpp
+++ b/core/sector_storage/sector_storage_error.hpp
@@ -19,6 +19,8 @@ namespace fc::sector_storage {
       CANNOT_REMOVE_DIR,
       DONOT_MATCH_SIZES,
       CANNOT_CREATE_FILE,
+      CANNOT_OPEN_FILE,
+      OUT_OF_FILE_SIZE,
       UNKNOWN = 1000 };
 
 }  // namespace fc::sector_storage


### PR DESCRIPTION
Signed-off-by: artyom-yurin <artem_yrin@mail.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Now Sector storage can unseal sealed files and read pieces from there
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
SectorStorage is full now
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
Copy into pipe
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs
Delegate control over the size of the top layers
<!-- Explain what other alternates were considered and why the proposed version was selected -->
