### PR TITLE
fix keystore - derive pubkey from address for signature verification

### DIFF
--- a/core/storage/keystore/keystore.cpp
+++ b/core/storage/keystore/keystore.cpp
@@ -7,89 +7,92 @@
 
 #include "common/visitor.hpp"
 
-using fc::crypto::signature::Signature;
-using fc::primitives::address::Protocol;
-using fc::storage::keystore::KeyStore;
-using fc::storage::keystore::KeyStoreError;
+namespace fc::storage::keystore {
 
-KeyStore::KeyStore(std::shared_ptr<BlsProvider> blsProvider,
-                   std::shared_ptr<Secp256k1ProviderDefault> secp256K1Provider)
-    : bls_provider_(std::move(blsProvider)),
-      secp256k1_provider_(std::move(secp256K1Provider)) {}
+  using crypto::signature::Signature;
+  using primitives::address::BLSPublicKeyHash;
+  using primitives::address::Protocol;
+  using primitives::address::Secp256k1PublicKeyHash;
 
-fc::outcome::result<bool> KeyStore::checkAddress(
-    const Address &address, const TPrivateKey &private_key) const noexcept {
-  if (!address.isKeyType()) return false;
+  KeyStore::KeyStore(
+      std::shared_ptr<BlsProvider> blsProvider,
+      std::shared_ptr<Secp256k1ProviderDefault> secp256K1Provider)
+      : bls_provider_(std::move(blsProvider)),
+        secp256k1_provider_(std::move(secp256K1Provider)) {}
 
-  // TODO(a.chernyshov): use visit_in_place
-  static_assert(std::is_same_v<BlsPrivateKey, Secp256k1PrivateKey>);
+  fc::outcome::result<bool> KeyStore::checkAddress(
+      const Address &address, const TPrivateKey &private_key) const noexcept {
+    if (!address.isKeyType()) return false;
 
-  if (address.getProtocol() == Protocol::BLS) {
-    OUTCOME_TRY(
-        public_key,
-        bls_provider_->derivePublicKey(boost::get<BlsPrivateKey>(private_key)));
-    return address.verifySyntax(public_key);
+    static_assert(std::is_same_v<BlsPrivateKey, Secp256k1PrivateKey>);
+
+    if (address.getProtocol() == Protocol::BLS) {
+      OUTCOME_TRY(public_key,
+                  bls_provider_->derivePublicKey(
+                      boost::get<BlsPrivateKey>(private_key)));
+      return address.verifySyntax(public_key);
+    }
+    if (address.getProtocol() == Protocol::SECP256K1) {
+      OUTCOME_TRY(public_key,
+                  secp256k1_provider_->derive(
+                      boost::get<Secp256k1PrivateKey>(private_key)));
+      return address.verifySyntax(public_key);
+    }
+
+    return KeyStoreError::WRONG_ADDRESS;
   }
-  if (address.getProtocol() == Protocol::SECP256K1) {
-    OUTCOME_TRY(public_key,
-                secp256k1_provider_->derive(
-                    boost::get<Secp256k1PrivateKey>(private_key)));
-    return address.verifySyntax(public_key);
+
+  fc::outcome::result<Signature> KeyStore::sign(
+      const Address &address, gsl::span<const uint8_t> data) noexcept {
+    OUTCOME_TRY(private_key, get(address));
+    OUTCOME_TRY(valid, checkAddress(address, private_key));
+    if (!valid) return KeyStoreError::WRONG_ADDRESS;
+
+    if (address.getProtocol() == Protocol::BLS) {
+      OUTCOME_TRY(
+          signature,
+          bls_provider_->sign(data, boost::get<BlsPrivateKey>(private_key)));
+      return signature;
+    }
+    if (address.getProtocol() == Protocol::SECP256K1) {
+      OUTCOME_TRY(signature,
+                  secp256k1_provider_->sign(
+                      data, boost::get<Secp256k1PrivateKey>(private_key)));
+      return std::move(signature);
+    }
+
+    return KeyStoreError::WRONG_ADDRESS;
   }
 
-  return KeyStoreError::WRONG_ADDRESS;
-}
-
-fc::outcome::result<Signature> KeyStore::sign(
-    const Address &address, gsl::span<const uint8_t> data) noexcept {
-  OUTCOME_TRY(private_key, get(address));
-  OUTCOME_TRY(valid, checkAddress(address, private_key));
-  if (!valid) return KeyStoreError::WRONG_ADDRESS;
-
-  if (address.getProtocol() == Protocol::BLS) {
-    OUTCOME_TRY(
+  fc::outcome::result<bool> KeyStore::verify(const Address &address,
+                                             gsl::span<const uint8_t> data,
+                                             const Signature &signature) const
+      noexcept {
+    return visit_in_place(
         signature,
-        bls_provider_->sign(data, boost::get<BlsPrivateKey>(private_key)));
-    return signature;
+        [this, address, data](
+            const BlsSignature &bls_signature) -> fc::outcome::result<bool> {
+          if (address.getProtocol() != Protocol::BLS
+              || address.data.type() != typeid(BLSPublicKeyHash)) {
+            return KeyStoreError::WRONG_SIGNATURE;
+          }
+
+          BlsPublicKey public_key{boost::get<BLSPublicKeyHash>(address.data)};
+          return bls_provider_->verifySignature(
+              data, bls_signature, public_key);
+        },
+        [this, address, data](const Secp256k1Signature &secp256k1_signature)
+            -> fc::outcome::result<bool> {
+          if (address.getProtocol() != Protocol::SECP256K1
+              || address.data.type() != typeid(Secp256k1PublicKeyHash)) {
+            return KeyStoreError::WRONG_SIGNATURE;
+          }
+
+          OUTCOME_TRY(
+              public_key,
+              secp256k1_provider_->recoverPublicKey(data, secp256k1_signature));
+          return address.verifySyntax(public_key);
+        });
   }
-  if (address.getProtocol() == Protocol::SECP256K1) {
-    OUTCOME_TRY(signature,
-                secp256k1_provider_->sign(
-                    data, boost::get<Secp256k1PrivateKey>(private_key)));
-    return std::move(signature);
-  }
 
-  return KeyStoreError::WRONG_ADDRESS;
-}
-
-fc::outcome::result<bool> KeyStore::verify(const Address &address,
-                                           gsl::span<const uint8_t> data,
-                                           const Signature &signature) const
-    noexcept {
-  OUTCOME_TRY(private_key, get(address));
-  OUTCOME_TRY(valid, checkAddress(address, private_key));
-  if (!valid) return KeyStoreError::WRONG_ADDRESS;
-
-  return visit_in_place(
-      signature,
-      [this, address, data, private_key](
-          const BlsSignature &bls_signature) -> fc::outcome::result<bool> {
-        if (address.getProtocol() != Protocol::BLS)
-          return KeyStoreError::WRONG_SIGNATURE;
-        OUTCOME_TRY(public_key,
-                    bls_provider_->derivePublicKey(
-                        boost::get<BlsPrivateKey>(private_key)));
-        return bls_provider_->verifySignature(data, bls_signature, public_key);
-      },
-      [this, address, data, private_key](
-          const Secp256k1Signature &secp256k1_signature)
-          -> fc::outcome::result<bool> {
-        if (address.getProtocol() != Protocol::SECP256K1)
-          return KeyStoreError::WRONG_SIGNATURE;
-        OUTCOME_TRY(public_key,
-                    secp256k1_provider_->derive(
-                        boost::get<Secp256k1PrivateKey>(private_key)));
-        return secp256k1_provider_->verify(
-            data, secp256k1_signature, public_key);
-      });
-}
+}  // namespace fc::storage::keystore

--- a/core/storage/keystore/keystore.hpp
+++ b/core/storage/keystore/keystore.hpp
@@ -23,9 +23,11 @@ namespace fc::storage::keystore {
   using crypto::secp256k1::Secp256k1ProviderDefault;
   using BlsKeyPair = crypto::bls::KeyPair;
   using BlsPrivateKey = crypto::bls::PrivateKey;
+  using BlsPublicKey = crypto::bls::PublicKey;
   using BlsSignature = crypto::bls::Signature;
   using Secp256k1KeyPair = crypto::secp256k1::KeyPair;
   using Secp256k1PrivateKey = crypto::secp256k1::PrivateKey;
+  using Secp256k1PublicKey = crypto::secp256k1::PublicKey;
   using Secp256k1Signature = crypto::secp256k1::Signature;
   using crypto::signature::Signature;
   using primitives::address::Address;
@@ -80,7 +82,7 @@ namespace fc::storage::keystore {
 
     /**
      * @brief verify signature
-     * @param address of keypair
+     * @param address - pubkey address
      * @param data
      * @param signature
      */

--- a/test/core/storage/keystore/filesystem_keystore_test.cpp
+++ b/test/core/storage/keystore/filesystem_keystore_test.cpp
@@ -15,275 +15,289 @@
 #include "testutil/outcome.hpp"
 #include "testutil/storage/base_fs_test.hpp"
 
-using fc::crypto::bls::BlsProvider;
-using fc::crypto::bls::BlsProviderImpl;
-using fc::crypto::secp256k1::Secp256k1Error;
-using fc::crypto::secp256k1::Secp256k1ProviderDefault;
-using fc::crypto::secp256k1::Secp256k1Sha256ProviderImpl;
-using fc::primitives::address::Address;
-using fc::primitives::address::Network;
-using fc::storage::keystore::FileSystemKeyStore;
-using fc::storage::keystore::KeyStore;
-using fc::storage::keystore::KeyStoreError;
-using BlsKeyPair = fc::crypto::bls::KeyPair;
-using Secp256k1KeyPair = fc::crypto::secp256k1::KeyPair;
-using BlsSignature = fc::crypto::bls::Signature;
-using Secp256k1Signature = fc::crypto::secp256k1::Signature;
-using BlsPublicKey = fc::crypto::bls::PublicKey;
-using Secp256k1PublicKey = fc::crypto::secp256k1::PublicKey;
-using fc::primitives::address::decode;
+namespace fc::storage::keystore {
 
-class FileSystemKeyStoreTest : public test::BaseFS_Test {
- public:
-  FileSystemKeyStoreTest() : test::BaseFS_Test("fc_filesystem_keystore_test") {}
+  using fc::crypto::bls::BlsProvider;
+  using fc::crypto::bls::BlsProviderImpl;
+  using fc::crypto::secp256k1::Secp256k1Error;
+  using fc::crypto::secp256k1::Secp256k1ProviderDefault;
+  using fc::crypto::secp256k1::Secp256k1Sha256ProviderImpl;
+  using fc::primitives::address::Address;
+  using fc::primitives::address::Network;
+  using BlsKeyPair = fc::crypto::bls::KeyPair;
+  using Secp256k1KeyPair = fc::crypto::secp256k1::KeyPair;
+  using BlsSignature = fc::crypto::bls::Signature;
+  using Secp256k1Signature = fc::crypto::secp256k1::Signature;
+  using BlsPublicKey = fc::crypto::bls::PublicKey;
+  using Secp256k1PublicKey = fc::crypto::secp256k1::PublicKey;
+  using fc::primitives::address::decode;
 
-  std::shared_ptr<BlsProvider> bls_provider_;
-  std::shared_ptr<BlsKeyPair> bls_keypair_;
-  Address bls_address_{};
+  class FileSystemKeyStoreTest : public test::BaseFS_Test {
+   public:
+    FileSystemKeyStoreTest()
+        : test::BaseFS_Test("fc_filesystem_keystore_test") {}
 
-  std::shared_ptr<Secp256k1ProviderDefault> secp256k1_provider_;
-  std::shared_ptr<Secp256k1KeyPair> secp256k1_keypair_;
-  Address secp256k1_address_{};
+    std::shared_ptr<BlsProvider> bls_provider_;
+    BlsKeyPair bls_keypair_;
+    Address bls_address_{};
 
-  std::shared_ptr<KeyStore> ks;
+    std::shared_ptr<Secp256k1ProviderDefault> secp256k1_provider_;
+    Secp256k1KeyPair secp256k1_keypair_;
+    Address secp256k1_address_{};
 
-  /** Some data to sign */
-  std::vector<uint8_t> data_{1, 1, 2, 3, 5, 8, 13, 21};
+    std::shared_ptr<KeyStore> ks;
+
+    /** Some data to sign */
+    std::vector<uint8_t> data_{1, 1, 2, 3, 5, 8, 13, 21};
+
+    /**
+     * Create crypto and directory.
+     */
+    void SetUp() override {
+      BaseFS_Test::SetUp();
+
+      bls_provider_ = std::make_shared<BlsProviderImpl>();
+      bls_keypair_ = bls_provider_->generateKeyPair().value();
+
+      bls_address_ = Address::makeBls(bls_keypair_.public_key);
+
+      secp256k1_provider_ = std::make_shared<Secp256k1Sha256ProviderImpl>();
+      secp256k1_keypair_ = secp256k1_provider_->generate().value();
+
+      secp256k1_address_ =
+          Address::makeSecp256k1(secp256k1_keypair_.public_key);
+
+      ks = std::make_shared<FileSystemKeyStore>(
+          base_path.string(), bls_provider_, secp256k1_provider_);
+    }
+
+   protected:
+    static bool VectorContains(const std::vector<Address> &vector,
+                               Address value) {
+      return std::find(vector.begin(), vector.end(), value) != vector.end();
+    }
+
+    bool checkSignature(gsl::span<uint8_t> message,
+                        const BlsSignature &signature,
+                        const BlsPublicKey &public_key) {
+      auto res = bls_provider_->verifySignature(message, signature, public_key);
+      if (res)
+        return res.value();
+      else
+        return false;
+    }
+
+    bool checkSignature(gsl::span<uint8_t> message,
+                        const Secp256k1Signature &signature,
+                        const Secp256k1PublicKey &public_key) {
+      auto res = secp256k1_provider_->verify(message, signature, public_key);
+      if (res)
+        return res.value();
+      else
+        return false;
+    }
+  };
 
   /**
-   * Create crypto and directory.
+   * @given Keystore is empty
+   * @when Has() is called
+   * @then success returned false
    */
-  void SetUp() override {
-    BaseFS_Test::SetUp();
-
-    bls_provider_ = std::make_shared<BlsProviderImpl>();
-    bls_keypair_ =
-        std::make_shared<BlsKeyPair>(bls_provider_->generateKeyPair().value());
-
-    bls_address_ = Address::makeBls(bls_keypair_->public_key);
-
-    secp256k1_provider_ = std::make_shared<Secp256k1Sha256ProviderImpl>();
-    secp256k1_keypair_ = std::make_shared<Secp256k1KeyPair>(
-        secp256k1_provider_->generate().value());
-
-    secp256k1_address_ = Address::makeSecp256k1(secp256k1_keypair_->public_key);
-
-    ks = std::make_shared<FileSystemKeyStore>(
-        base_path.string(), bls_provider_, secp256k1_provider_);
+  TEST_F(FileSystemKeyStoreTest, HasEmpty) {
+    EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
+    ASSERT_FALSE(found);
   }
 
- protected:
-  static bool VectorContains(const std::vector<Address> &vector,
-                             Address value) {
-    return std::find(vector.begin(), vector.end(), value) != vector.end();
+  /**
+   * @given Keystore, public key and address
+   * @when try to insert key that already is in Keystore
+   * @then ALREADY_EXISTS returned
+   */
+  TEST_F(FileSystemKeyStoreTest, AddressAlreadyStored) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_ERROR(KeyStoreError::ALREADY_EXISTS,
+                         ks->put(bls_address_, bls_keypair_.private_key));
   }
 
-  bool checkSignature(gsl::span<uint8_t> message,
-                      const BlsSignature &signature,
-                      const BlsPublicKey &public_key) {
-    auto res = bls_provider_->verifySignature(message, signature, public_key);
-    if (res)
-      return res.value();
-    else
-      return false;
+  /**
+   * @given Keystore, public key and address
+   * @when try to remove key that is not in Keystore
+   * @then NOT_FOUND returned
+   */
+  TEST_F(FileSystemKeyStoreTest, RemoveNotExists) {
+    EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND, ks->remove(bls_address_));
   }
 
-  bool checkSignature(gsl::span<uint8_t> message,
-                      const Secp256k1Signature &signature,
-                      const Secp256k1PublicKey &public_key) {
-    auto res = secp256k1_provider_->verify(message, signature, public_key);
-    if (res)
-      return res.value();
-    else
-      return false;
+  /**
+   * @given Keystore, public key and address
+   * @when add key to Keystore and then delete it
+   * @then success returned, key not found
+   */
+  TEST_F(FileSystemKeyStoreTest, AddAndRemove) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+
+    EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
+    ASSERT_TRUE(found);
+
+    EXPECT_OUTCOME_TRUE_1(ks->remove(bls_address_));
+    EXPECT_OUTCOME_TRUE(not_found, ks->has(bls_address_));
+    ASSERT_FALSE(not_found);
   }
-};
 
-/**
- * @given Keystore is empty
- * @when Has() is called
- * @then success returned false
- */
-TEST_F(FileSystemKeyStoreTest, HasEmpty) {
-  EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
-  ASSERT_FALSE(found);
-}
+  /**
+   * @given Keystore is empty
+   * @when call list
+   * @then empty list returned
+   */
+  TEST_F(FileSystemKeyStoreTest, ListEmpty) {
+    EXPECT_OUTCOME_TRUE(list, ks->list());
+    ASSERT_EQ(0, list.size());
+  }
 
-/**
- * @given Keystore, public key and address
- * @when try to insert key that already is in Keystore
- * @then ALREADY_EXISTS returned
- */
-TEST_F(FileSystemKeyStoreTest, AddressAlreadyStored) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_ERROR(KeyStoreError::ALREADY_EXISTS,
-                       ks->put(bls_address_, bls_keypair_->private_key));
-}
+  /**
+   * @given Keystore stores 2 keys
+   * @when call list
+   * @then list containing all addresses returned
+   */
+  TEST_F(FileSystemKeyStoreTest, ListKeys) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE_1(
+        ks->put(secp256k1_address_, secp256k1_keypair_.private_key));
 
-/**
- * @given Keystore, public key and address
- * @when try to remove key that is not in Keystore
- * @then NOT_FOUND returned
- */
-TEST_F(FileSystemKeyStoreTest, RemoveNotExists) {
-  EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND, ks->remove(bls_address_));
-}
+    EXPECT_OUTCOME_TRUE(list, ks->list());
+    ASSERT_EQ(2, list.size());
+    ASSERT_TRUE(VectorContains(list, bls_address_));
+    ASSERT_TRUE(VectorContains(list, secp256k1_address_));
+  }
 
-/**
- * @given Keystore, public key and address
- * @when add key to Keystore and then delete it
- * @then success returned, key not found
- */
-TEST_F(FileSystemKeyStoreTest, AddAndRemove) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
+  /**
+   * @given empty Keystore
+   * @when sign with wrong address
+   * @then NOT_FOUND returned
+   */
+  TEST_F(FileSystemKeyStoreTest, SignNotFound) {
+    EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND,
+                         ks->sign(bls_address_, data_));
+  }
 
-  EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
-  ASSERT_TRUE(found);
+  /**
+   * @given empty Keystore
+   * @when put malformed address
+   * @then WRONG_ADDRESS returned
+   */
+  TEST_F(FileSystemKeyStoreTest, SignWrongAddress) {
+    // generate id address (type 0) which has no key
+    std::vector<uint8_t> bytes{0x0, 0xD1, 0xC2, 0xA7, 0x0F};
+    auto wrong_address = decode(bytes).value();
+    EXPECT_OUTCOME_ERROR(KeyStoreError::WRONG_ADDRESS,
+                         ks->put(wrong_address, bls_keypair_.private_key));
+  }
 
-  EXPECT_OUTCOME_TRUE_1(ks->remove(bls_address_));
-  EXPECT_OUTCOME_TRUE(not_found, ks->has(bls_address_));
-  ASSERT_FALSE(not_found);
-}
+  /**
+   * @given Kestore with bls private key
+   * @when Sign() called with bls crypto
+   * @then correct signature returned
+   */
+  TEST_F(FileSystemKeyStoreTest, SignCorrectBls) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(signature, ks->sign(bls_address_, data_));
+    auto bls_signature = boost::get<BlsSignature>(signature);
+    ASSERT_TRUE(checkSignature(data_, bls_signature, bls_keypair_.public_key));
+  }
 
-/**
- * @given Keystore is empty
- * @when call list
- * @then empty list returned
- */
-TEST_F(FileSystemKeyStoreTest, ListEmpty) {
-  EXPECT_OUTCOME_TRUE(list, ks->list());
-  ASSERT_EQ(0, list.size());
-}
+  /**
+   * @given Kestore with secp256k1 private key
+   * @when Sign() called with bls crypto
+   * @then correct signature returned
+   */
+  TEST_F(FileSystemKeyStoreTest, SignCorrectSecp256k1) {
+    EXPECT_OUTCOME_TRUE_1(
+        ks->put(secp256k1_address_, secp256k1_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(signature, ks->sign(secp256k1_address_, data_));
+    auto secp256k1_signature = boost::get<Secp256k1Signature>(signature);
+    ASSERT_TRUE(checkSignature(
+        data_, secp256k1_signature, secp256k1_keypair_.public_key));
+  }
 
-/**
- * @given Keystore stores 2 keys
- * @when call list
- * @then list containing all addresses returned
- */
-TEST_F(FileSystemKeyStoreTest, ListKeys) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
+  /**
+   * @given empty Keystore
+   * @when Verify() with wrong address
+   * @then false returned
+   */
+  TEST_F(FileSystemKeyStoreTest, VerifyNotFound) {
+    BlsSignature signature;
+    EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
+    ASSERT_FALSE(res);
+  }
 
-  EXPECT_OUTCOME_TRUE(list, ks->list());
-  ASSERT_EQ(2, list.size());
-  ASSERT_TRUE(VectorContains(list, bls_address_));
-  ASSERT_TRUE(VectorContains(list, secp256k1_address_));
-}
+  /**
+   * @given Keystore with bls private key
+   * @when Verify() called with wrong signature
+   * @then false returned
+   */
+  TEST_F(FileSystemKeyStoreTest, VerifyWrongBls) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    BlsSignature signature;
+    EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
+    ASSERT_FALSE(res);
+  }
 
-/**
- * @given empty Keystore
- * @when sign with wrong address
- * @then NOT_FOUND returned
- */
-TEST_F(FileSystemKeyStoreTest, SignNotFound) {
-  EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND, ks->sign(bls_address_, data_));
-}
+  /**
+   * @given Kestore with secp256k1 private key
+   * @when Verify() called with invalid signature
+   * @then false returned
+   */
+  TEST_F(FileSystemKeyStoreTest, InvalidSecp256k1Signature) {
+    EXPECT_OUTCOME_TRUE_1(
+        ks->put(secp256k1_address_, secp256k1_keypair_.private_key));
+    Secp256k1Signature invalid_signature;
+    invalid_signature[64] = 99;
+    EXPECT_OUTCOME_ERROR(
+        Secp256k1Error::SIGNATURE_PARSE_ERROR,
+        ks->verify(secp256k1_address_, data_, invalid_signature));
+  }
 
-/**
- * @given empty Keystore
- * @when put malformed address
- * @then WRONG_ADDRESS returned
- */
-TEST_F(FileSystemKeyStoreTest, SignWrongAddress) {
-  // generate id address (type 0) which has no key
-  std::vector<uint8_t> bytes{0x0, 0xD1, 0xC2, 0xA7, 0x0F};
-  auto wrong_address = decode(bytes).value();
-  EXPECT_OUTCOME_ERROR(KeyStoreError::WRONG_ADDRESS,
-                       ks->put(wrong_address, bls_keypair_->private_key));
-}
+  /**
+   * @given Kestore and secp256k1 signature and public key
+   * @when Verify() called with signature
+   * @then true returned
+   */
+  TEST_F(FileSystemKeyStoreTest, VerifySecp256k1Signature) {
+    EXPECT_OUTCOME_TRUE(
+        wrong_signature,
+        secp256k1_provider_->sign(data_, secp256k1_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(res,
+                        ks->verify(secp256k1_address_, data_, wrong_signature));
+    ASSERT_TRUE(res);
+  }
 
-/**
- * @given Kestore with bls private key
- * @when Sign() called with bls crypto
- * @then correct signature returned
- */
-TEST_F(FileSystemKeyStoreTest, SignCorrectBls) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(signature, ks->sign(bls_address_, data_));
-  auto bls_signature = boost::get<BlsSignature>(signature);
-  ASSERT_TRUE(checkSignature(data_, bls_signature, bls_keypair_->public_key));
-}
+  /**
+   * @given Keystore and secp256k1 signature and wrong public key
+   * @when Verify() called with wrong public ket
+   * @then false returned
+   */
+  TEST_F(FileSystemKeyStoreTest, VerifyWrongSecp256k1Signature) {
+    EXPECT_OUTCOME_TRUE(other_keypair, secp256k1_provider_->generate());
+    Address other_address = Address::makeSecp256k1(other_keypair.public_key);
 
-/**
- * @given Kestore with secp256k1 private key
- * @when Sign() called with bls crypto
- * @then correct signature returned
- */
-TEST_F(FileSystemKeyStoreTest, SignCorrectSecp256k1) {
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(signature, ks->sign(secp256k1_address_, data_));
-  auto secp256k1_signature = boost::get<Secp256k1Signature>(signature);
-  ASSERT_TRUE(checkSignature(
-      data_, secp256k1_signature, secp256k1_keypair_->public_key));
-}
+    EXPECT_OUTCOME_TRUE(
+        secp256k1_signature,
+        secp256k1_provider_->sign(data_, secp256k1_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(res,
+                        ks->verify(other_address, data_, secp256k1_signature));
+    ASSERT_FALSE(res);
+  }
 
-/**
- * @given empty Keystore
- * @when Verify() with wrong address
- * @then NOT_FOUND returned
- */
-TEST_F(FileSystemKeyStoreTest, VerifyNotFound) {
-  BlsSignature signature;
-  EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND,
-                       ks->verify(bls_address_, data_, signature));
-}
+  /**
+   * @given Keystore with and bls signature and public key
+   * @when Verify() called with signature
+   * @then true returned
+   */
+  TEST_F(FileSystemKeyStoreTest, VerifyCorrectBls) {
+    EXPECT_OUTCOME_TRUE(signature,
+                        bls_provider_->sign(data_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
+    ASSERT_TRUE(res);
+  }
 
-/**
- * @given Keystore with bls private key
- * @when Verify() called with wrong signature
- * @then false returned
- */
-TEST_F(FileSystemKeyStoreTest, VerifyWrongBls) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  BlsSignature signature;
-  EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
-  ASSERT_FALSE(res);
-}
-
-/**
- * @given Kestore with secp256k1 private key
- * @when Verify() called with invalid signature
- * @then false returned
- */
-TEST_F(FileSystemKeyStoreTest, InvalidSecp256k1Signature) {
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
-  Secp256k1Signature invalid_signature;
-  invalid_signature[64] = 99;
-  EXPECT_OUTCOME_ERROR(
-      Secp256k1Error::SIGNATURE_PARSE_ERROR,
-      ks->verify(secp256k1_address_, data_, invalid_signature));
-}
-
-/**
- * @given Kestore with secp256k1 private key
- * @when Verify() called with wrong signature
- * @then false returned
- */
-TEST_F(FileSystemKeyStoreTest, WrongSecp256k1Signature) {
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
-
-  EXPECT_OUTCOME_TRUE(other_keypair, secp256k1_provider_->generate());
-  EXPECT_OUTCOME_TRUE(
-      wrong_signature,
-      secp256k1_provider_->sign(data_, other_keypair.private_key));
-  EXPECT_OUTCOME_TRUE(res,
-                      ks->verify(secp256k1_address_, data_, wrong_signature));
-  ASSERT_FALSE(res);
-}
-
-/**
- * @given Keystore with bls private key
- * @when Verify() called with correct signature
- * @then true returned
- */
-TEST_F(FileSystemKeyStoreTest, VerifyCorrectBls) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(signature,
-                      bls_provider_->sign(data_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
-  ASSERT_TRUE(res);
-}
+}  // namespace fc::storage::keystore

--- a/test/core/storage/keystore/in_memory_keystore_test.cpp
+++ b/test/core/storage/keystore/in_memory_keystore_test.cpp
@@ -15,268 +15,282 @@
 #include "primitives/address/address_codec.hpp"
 #include "testutil/outcome.hpp"
 
-using fc::crypto::bls::BlsProvider;
-using fc::crypto::bls::BlsProviderImpl;
-using fc::crypto::secp256k1::Secp256k1Error;
-using fc::crypto::secp256k1::Secp256k1ProviderDefault;
-using fc::crypto::secp256k1::Secp256k1Sha256ProviderImpl;
-using fc::primitives::address::Address;
-using fc::primitives::address::Network;
-using fc::storage::keystore::InMemoryKeyStore;
-using fc::storage::keystore::KeyStore;
-using fc::storage::keystore::KeyStoreError;
-using BlsKeyPair = fc::crypto::bls::KeyPair;
-using Secp256k1KeyPair = fc::crypto::secp256k1::KeyPair;
-using BlsSignature = fc::crypto::bls::Signature;
-using Secp256k1Signature = fc::crypto::secp256k1::Signature;
-using BlsPublicKey = fc::crypto::bls::PublicKey;
-using Secp256k1PublicKey = fc::crypto::secp256k1::PublicKey;
-using fc::primitives::address::decode;
+namespace fc::storage::keystore {
 
-class InMemoryKeyStoreTest : public ::testing::Test {
- public:
-  std::shared_ptr<BlsProvider> bls_provider_ =
-      std::make_shared<BlsProviderImpl>();
-  std::shared_ptr<BlsKeyPair> bls_keypair_;
-  Address bls_address_{};
+  using fc::crypto::bls::BlsProvider;
+  using fc::crypto::bls::BlsProviderImpl;
+  using fc::crypto::secp256k1::Secp256k1Error;
+  using fc::crypto::secp256k1::Secp256k1ProviderDefault;
+  using fc::crypto::secp256k1::Secp256k1Sha256ProviderImpl;
+  using fc::primitives::address::Address;
+  using fc::primitives::address::Network;
+  using BlsKeyPair = fc::crypto::bls::KeyPair;
+  using Secp256k1KeyPair = fc::crypto::secp256k1::KeyPair;
+  using BlsSignature = fc::crypto::bls::Signature;
+  using Secp256k1Signature = fc::crypto::secp256k1::Signature;
+  using BlsPublicKey = fc::crypto::bls::PublicKey;
+  using Secp256k1PublicKey = fc::crypto::secp256k1::PublicKey;
+  using fc::primitives::address::decode;
 
-  std::shared_ptr<Secp256k1ProviderDefault> secp256k1_provider_ =
-      std::make_shared<Secp256k1Sha256ProviderImpl>();
-  std::shared_ptr<Secp256k1KeyPair> secp256k1_keypair_;
-  Address secp256k1_address_{};
+  class InMemoryKeyStoreTest : public ::testing::Test {
+   public:
+    std::shared_ptr<BlsProvider> bls_provider_ =
+        std::make_shared<BlsProviderImpl>();
+    BlsKeyPair bls_keypair_;
+    Address bls_address_{};
 
-  std::shared_ptr<KeyStore> ks;
+    std::shared_ptr<Secp256k1ProviderDefault> secp256k1_provider_ =
+        std::make_shared<Secp256k1Sha256ProviderImpl>();
+    Secp256k1KeyPair secp256k1_keypair_;
+    Address secp256k1_address_{};
 
-  /** Some data to sign */
-  std::vector<uint8_t> data_{1, 1, 2, 3, 5, 8, 13, 21};
+    std::shared_ptr<KeyStore> ks;
+
+    /** Some data to sign */
+    std::vector<uint8_t> data_{1, 1, 2, 3, 5, 8, 13, 21};
+
+    /**
+     * Create crypto.
+     */
+    void SetUp() override {
+      bls_keypair_ = bls_provider_->generateKeyPair().value();
+      bls_address_ = Address::makeBls(bls_keypair_.public_key);
+
+      secp256k1_keypair_ = secp256k1_provider_->generate().value();
+      secp256k1_address_ =
+          Address::makeSecp256k1(secp256k1_keypair_.public_key);
+
+      ks = std::make_shared<InMemoryKeyStore>(bls_provider_,
+                                              secp256k1_provider_);
+    }
+
+   protected:
+    static bool VectorContains(const std::vector<Address> &vector,
+                               Address value) {
+      return std::find(vector.begin(), vector.end(), value) != vector.end();
+    }
+
+    bool checkSignature(gsl::span<uint8_t> message,
+                        const BlsSignature &signature,
+                        const BlsPublicKey &public_key) {
+      auto res = bls_provider_->verifySignature(message, signature, public_key);
+      if (res)
+        return res.value();
+      else
+        return false;
+    }
+
+    bool checkSignature(gsl::span<uint8_t> message,
+                        const Secp256k1Signature &signature,
+                        const Secp256k1PublicKey &public_key) {
+      auto res = secp256k1_provider_->verify(message, signature, public_key);
+      if (res)
+        return res.value();
+      else
+        return false;
+    }
+  };
 
   /**
-   * Create crypto.
+   * @given Keystore is empty
+   * @when Has() is called
+   * @then success returned false
    */
-  void SetUp() override {
-    bls_keypair_ =
-        std::make_shared<BlsKeyPair>(bls_provider_->generateKeyPair().value());
-    bls_address_ = Address::makeBls(bls_keypair_->public_key);
-
-    secp256k1_keypair_ = std::make_shared<Secp256k1KeyPair>(
-        secp256k1_provider_->generate().value());
-    secp256k1_address_ = Address::makeSecp256k1(secp256k1_keypair_->public_key);
-
-    ks = std::make_shared<InMemoryKeyStore>(bls_provider_, secp256k1_provider_);
+  TEST_F(InMemoryKeyStoreTest, HasEmpty) {
+    EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
+    ASSERT_FALSE(found);
   }
 
- protected:
-  static bool VectorContains(const std::vector<Address> &vector,
-                             Address value) {
-    return std::find(vector.begin(), vector.end(), value) != vector.end();
+  /**
+   * @given Keystore, public key and address
+   * @when try to insert key that already is in Keystore
+   * @then ALREADY_EXISTS returned
+   */
+  TEST_F(InMemoryKeyStoreTest, AddressAlreadyStored) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_ERROR(KeyStoreError::ALREADY_EXISTS,
+                         ks->put(bls_address_, bls_keypair_.private_key));
   }
 
-  bool checkSignature(gsl::span<uint8_t> message,
-                      const BlsSignature &signature,
-                      const BlsPublicKey &public_key) {
-    auto res = bls_provider_->verifySignature(message, signature, public_key);
-    if (res)
-      return res.value();
-    else
-      return false;
+  /**
+   * @given Keystore, public key and address
+   * @when try to remove key that is not in Keystore
+   * @then NOT_FOUND returned
+   */
+  TEST_F(InMemoryKeyStoreTest, RemoveNotExists) {
+    EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND, ks->remove(bls_address_));
   }
 
-  bool checkSignature(gsl::span<uint8_t> message,
-                      const Secp256k1Signature &signature,
-                      const Secp256k1PublicKey &public_key) {
-    auto res = secp256k1_provider_->verify(message, signature, public_key);
-    if (res)
-      return res.value();
-    else
-      return false;
+  /**
+   * @given Keystore, public key and address
+   * @when add key to Keystore and then delete it
+   * @then success returned, key not found
+   */
+  TEST_F(InMemoryKeyStoreTest, AddAndRemove) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+
+    EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
+    ASSERT_TRUE(found);
+
+    EXPECT_OUTCOME_TRUE_1(ks->remove(bls_address_));
+    EXPECT_OUTCOME_TRUE(not_found, ks->has(bls_address_));
+    ASSERT_FALSE(not_found);
   }
-};
 
-/**
- * @given Keystore is empty
- * @when Has() is called
- * @then success returned false
- */
-TEST_F(InMemoryKeyStoreTest, HasEmpty) {
-  EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
-  ASSERT_FALSE(found);
-}
+  /**
+   * @given Keystore is empty
+   * @when call list
+   * @then empty list returned
+   */
+  TEST_F(InMemoryKeyStoreTest, ListEmpty) {
+    EXPECT_OUTCOME_TRUE(list, ks->list());
+    ASSERT_EQ(0, list.size());
+  }
 
-/**
- * @given Keystore, public key and address
- * @when try to insert key that already is in Keystore
- * @then ALREADY_EXISTS returned
- */
-TEST_F(InMemoryKeyStoreTest, AddressAlreadyStored) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_ERROR(KeyStoreError::ALREADY_EXISTS,
-                       ks->put(bls_address_, bls_keypair_->private_key));
-}
+  /**
+   * @given Keystore stores 2 keys
+   * @when call list
+   * @then list containing all addresses returned
+   */
+  TEST_F(InMemoryKeyStoreTest, ListKeys) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE_1(
+        ks->put(secp256k1_address_, secp256k1_keypair_.private_key));
 
-/**
- * @given Keystore, public key and address
- * @when try to remove key that is not in Keystore
- * @then NOT_FOUND returned
- */
-TEST_F(InMemoryKeyStoreTest, RemoveNotExists) {
-  EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND, ks->remove(bls_address_));
-}
+    EXPECT_OUTCOME_TRUE(list, ks->list());
+    ASSERT_EQ(2, list.size());
+    ASSERT_TRUE(VectorContains(list, bls_address_));
+    ASSERT_TRUE(VectorContains(list, secp256k1_address_));
+  }
 
-/**
- * @given Keystore, public key and address
- * @when add key to Keystore and then delete it
- * @then success returned, key not found
- */
-TEST_F(InMemoryKeyStoreTest, AddAndRemove) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
+  /**
+   * @given empty Keystore
+   * @when sign with wrong address
+   * @then NOT_FOUND returned
+   */
+  TEST_F(InMemoryKeyStoreTest, SignNotFound) {
+    EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND,
+                         ks->sign(bls_address_, data_));
+  }
 
-  EXPECT_OUTCOME_TRUE(found, ks->has(bls_address_));
-  ASSERT_TRUE(found);
+  /**
+   * @given empty Keystore
+   * @when put malformed address
+   * @then WRONG_ADDRESS returned
+   */
+  TEST_F(InMemoryKeyStoreTest, SignWrongAddress) {
+    // generate id address (type 0) which has no key
+    std::vector<uint8_t> bytes{0x0, 0xD1, 0xC2, 0xA7, 0x0F};
+    auto wrong_address = decode(bytes).value();
+    EXPECT_OUTCOME_ERROR(KeyStoreError::WRONG_ADDRESS,
+                         ks->put(wrong_address, bls_keypair_.private_key));
+  }
 
-  EXPECT_OUTCOME_TRUE_1(ks->remove(bls_address_));
-  EXPECT_OUTCOME_TRUE(not_found, ks->has(bls_address_));
-  ASSERT_FALSE(not_found);
-}
+  /**
+   * @given Kestore with bls private key
+   * @when Sign() called with bls crypto
+   * @then correct signature returned
+   */
+  TEST_F(InMemoryKeyStoreTest, SignCorrectBls) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(signature, ks->sign(bls_address_, data_));
+    auto bls_signature = boost::get<BlsSignature>(signature);
+    ASSERT_TRUE(checkSignature(data_, bls_signature, bls_keypair_.public_key));
+  }
 
-/**
- * @given Keystore is empty
- * @when call list
- * @then empty list returned
- */
-TEST_F(InMemoryKeyStoreTest, ListEmpty) {
-  EXPECT_OUTCOME_TRUE(list, ks->list());
-  ASSERT_EQ(0, list.size());
-}
+  /**
+   * @given Kestore with secp256k1 private key
+   * @when Sign() called with bls crypto
+   * @then correct signature returned
+   */
+  TEST_F(InMemoryKeyStoreTest, SignCorrectSecp256k1) {
+    EXPECT_OUTCOME_TRUE_1(
+        ks->put(secp256k1_address_, secp256k1_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(signature, ks->sign(secp256k1_address_, data_));
+    auto secp256k1_signature = boost::get<Secp256k1Signature>(signature);
+    ASSERT_TRUE(checkSignature(
+        data_, secp256k1_signature, secp256k1_keypair_.public_key));
+  }
 
-/**
- * @given Keystore stores 2 keys
- * @when call list
- * @then list containing all addresses returned
- */
-TEST_F(InMemoryKeyStoreTest, ListKeys) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
+  /**
+   * @given empty Keystore
+   * @when Verify() with wrong address
+   * @then false returned
+   */
+  TEST_F(InMemoryKeyStoreTest, VerifyNotFound) {
+    BlsSignature signature;
+    EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
+    ASSERT_FALSE(res);
+  }
 
-  EXPECT_OUTCOME_TRUE(list, ks->list());
-  ASSERT_EQ(2, list.size());
-  ASSERT_TRUE(VectorContains(list, bls_address_));
-  ASSERT_TRUE(VectorContains(list, secp256k1_address_));
-}
+  /**
+   * @given Keystore with bls private key
+   * @when Verify() called with wrong signature
+   * @then false returned
+   */
+  TEST_F(InMemoryKeyStoreTest, VerifyWrongBls) {
+    EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_.private_key));
+    BlsSignature signature;
+    EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
+    ASSERT_FALSE(res);
+  }
 
-/**
- * @given empty Keystore
- * @when sign with wrong address
- * @then NOT_FOUND returned
- */
-TEST_F(InMemoryKeyStoreTest, SignNotFound) {
-  EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND, ks->sign(bls_address_, data_));
-}
+  /**
+   * @given Kestore with secp256k1 private key
+   * @when Verify() called with invalid signature
+   * @then false returned
+   */
+  TEST_F(InMemoryKeyStoreTest, InvalidSecp256k1Signature) {
+    EXPECT_OUTCOME_TRUE_1(
+        ks->put(secp256k1_address_, secp256k1_keypair_.private_key));
+    Secp256k1Signature invalid_signature;
+    invalid_signature[64] = 99;
+    EXPECT_OUTCOME_ERROR(
+        Secp256k1Error::SIGNATURE_PARSE_ERROR,
+        ks->verify(secp256k1_address_, data_, invalid_signature));
+  }
 
-/**
- * @given empty Keystore
- * @when put malformed address
- * @then WRONG_ADDRESS returned
- */
-TEST_F(InMemoryKeyStoreTest, SignWrongAddress) {
-  // generate id address (type 0) which has no key
-  std::vector<uint8_t> bytes{0x0, 0xD1, 0xC2, 0xA7, 0x0F};
-  auto wrong_address = decode(bytes).value();
-  EXPECT_OUTCOME_ERROR(KeyStoreError::WRONG_ADDRESS,
-                       ks->put(wrong_address, bls_keypair_->private_key));
-}
+  /**
+   * @given Keystore and secp256k1 signature and public key
+   * @when Verify() called with other signature
+   * @then true returned
+   */
+  TEST_F(InMemoryKeyStoreTest, VerifySecp256k1Signature) {
+    EXPECT_OUTCOME_TRUE(
+        secp256k1_signature,
+        secp256k1_provider_->sign(data_, secp256k1_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(
+        res, ks->verify(secp256k1_address_, data_, secp256k1_signature));
+    ASSERT_TRUE(res);
+  }
 
-/**
- * @given Kestore with bls private key
- * @when Sign() called with bls crypto
- * @then correct signature returned
- */
-TEST_F(InMemoryKeyStoreTest, SignCorrectBls) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(signature, ks->sign(bls_address_, data_));
-  auto bls_signature = boost::get<BlsSignature>(signature);
-  ASSERT_TRUE(checkSignature(data_, bls_signature, bls_keypair_->public_key));
-}
+  /**
+   * @given Keystore and secp256k1 signature and wrong public key
+   * @when Verify() called with wrong public ket
+   * @then false returned
+   */
+  TEST_F(InMemoryKeyStoreTest, VerifyWrongSecp256k1Signature) {
+    EXPECT_OUTCOME_TRUE(other_keypair, secp256k1_provider_->generate());
+    Address other_address = Address::makeSecp256k1(other_keypair.public_key);
 
-/**
- * @given Kestore with secp256k1 private key
- * @when Sign() called with bls crypto
- * @then correct signature returned
- */
-TEST_F(InMemoryKeyStoreTest, SignCorrectSecp256k1) {
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(signature, ks->sign(secp256k1_address_, data_));
-  auto secp256k1_signature = boost::get<Secp256k1Signature>(signature);
-  ASSERT_TRUE(checkSignature(
-      data_, secp256k1_signature, secp256k1_keypair_->public_key));
-}
+    EXPECT_OUTCOME_TRUE(
+        secp256k1_signature,
+        secp256k1_provider_->sign(data_, secp256k1_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(res,
+                        ks->verify(other_address, data_, secp256k1_signature));
+    ASSERT_FALSE(res);
+  }
 
-/**
- * @given empty Keystore
- * @when Verify() with wrong address
- * @then NOT_FOUND returned
- */
-TEST_F(InMemoryKeyStoreTest, VerifyNotFound) {
-  BlsSignature signature;
-  EXPECT_OUTCOME_ERROR(KeyStoreError::NOT_FOUND,
-                       ks->verify(bls_address_, data_, signature));
-}
+  /**
+   * @given Keystore and bls signature and public key
+   * @when Verify() called with correct signature
+   * @then true returned
+   */
+  TEST_F(InMemoryKeyStoreTest, VerifyCorrectBls) {
+    EXPECT_OUTCOME_TRUE(bls_signature,
+                        bls_provider_->sign(data_, bls_keypair_.private_key));
+    EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, bls_signature));
+    ASSERT_TRUE(res);
+  }
 
-/**
- * @given Keystore with bls private key
- * @when Verify() called with wrong signature
- * @then false returned
- */
-TEST_F(InMemoryKeyStoreTest, VerifyWrongBls) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  BlsSignature signature;
-  EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
-  ASSERT_FALSE(res);
-}
-
-/**
- * @given Kestore with secp256k1 private key
- * @when Verify() called with invalid signature
- * @then false returned
- */
-TEST_F(InMemoryKeyStoreTest, InvalidSecp256k1Signature) {
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
-  Secp256k1Signature invalid_signature;
-  invalid_signature[64] = 99;
-  EXPECT_OUTCOME_ERROR(
-      Secp256k1Error::SIGNATURE_PARSE_ERROR,
-      ks->verify(secp256k1_address_, data_, invalid_signature));
-}
-
-/**
- * @given Kestore with secp256k1 private key
- * @when Verify() called with wrong signature
- * @then false returned
- */
-TEST_F(InMemoryKeyStoreTest, WrongSecp256k1Signature) {
-  EXPECT_OUTCOME_TRUE_1(
-      ks->put(secp256k1_address_, secp256k1_keypair_->private_key));
-
-  EXPECT_OUTCOME_TRUE(other_keypair, secp256k1_provider_->generate());
-  EXPECT_OUTCOME_TRUE(
-      wrong_signature,
-      secp256k1_provider_->sign(data_, other_keypair.private_key));
-  EXPECT_OUTCOME_TRUE(res,
-                      ks->verify(secp256k1_address_, data_, wrong_signature));
-  ASSERT_FALSE(res);
-}
-
-/**
- * @given Keystore with bls private key
- * @when Verify() called with correct signature
- * @then true returned
- */
-TEST_F(InMemoryKeyStoreTest, VerifyCorrectBls) {
-  EXPECT_OUTCOME_TRUE_1(ks->put(bls_address_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(signature,
-                      bls_provider_->sign(data_, bls_keypair_->private_key));
-  EXPECT_OUTCOME_TRUE(res, ks->verify(bls_address_, data_, signature));
-  ASSERT_TRUE(res);
-}
+}  // namespace fc::storage::keystore


### PR DESCRIPTION
Signed-off-by: Alexey-N-Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
KeyStore::verify() method now takes public key from provided address (hash from secp256k1 and raw bytes for BLS).
Tests are refactored.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
