### PR TITLE
Update drand proto and message parser

### DIFF
--- a/core/drand/example/drand_example.cpp
+++ b/core/drand/example/drand_example.cpp
@@ -27,10 +27,16 @@ int main(int argc, char *argv[]) {
       std::make_shared<fc::drand::DrandSyncClientImpl>(
           std::string(argv[1]), std::stoi(std::string(argv[2])));
 
-  auto result = client->publicRand(1);
-  std::cout << static_cast<int>(result.has_value()) << std::endl;
-  for (auto e : result.value().randomness) {
-    std::cout << e;
+  if (auto result = client->publicRand(1)) {
+    std::cout << static_cast<int>(result.has_value()) << std::endl;
+    for (auto e : result.value().randomness) {
+      std::cout << e;
+    }
+    std::cout << std::endl;
+  }
+
+  if (auto result = client->group()) {
+    std::cout << "Dist Keys " << result.value().dist_key.size() << std::endl;
   }
   return 0;
 }

--- a/core/drand/impl/parser.cpp
+++ b/core/drand/impl/parser.cpp
@@ -14,13 +14,10 @@ namespace fc::drand {
                     .key = {identity.key().begin(), identity.key().end()},
                     .tls = identity.tls()};
   }
-  Node ProtoParser::protoToHandy(const ::drand::Node &node) {
-    return Node{.public_identity = protoToHandy(node.public_()),
-                .index = node.index()};
-  }
+
   GroupPacket ProtoParser::protoToHandy(
       const ::drand::GroupPacket &group_packet) {
-    std::vector<Node> nodes;
+    std::vector<Identity> nodes;
     nodes.reserve(group_packet.nodes_size());
     for (auto i = 0; i < group_packet.nodes_size(); ++i) {
       nodes.push_back(protoToHandy(group_packet.nodes(i)));

--- a/core/drand/impl/parser.hpp
+++ b/core/drand/impl/parser.hpp
@@ -22,8 +22,6 @@ namespace fc::drand {
    public:
     static Identity protoToHandy(const ::drand::Identity &identity);
 
-    static Node protoToHandy(const ::drand::Node &node);
-
     static GroupPacket protoToHandy(const ::drand::GroupPacket &group_packet);
 
     static PublicRandResponse protoToHandy(

--- a/core/drand/messages.hpp
+++ b/core/drand/messages.hpp
@@ -24,13 +24,8 @@ namespace fc::drand {
     bool tls;
   };
 
-  struct Node {
-    Identity public_identity;  // named as "public" in drand proto
-    uint32_t index;
-  };
-
   struct GroupPacket {
-    std::vector<Node> nodes;
+    std::vector<Identity> nodes;
     uint32_t threshold;
     uint32_t period;  // in seconds
     uint64_t genesis_time;

--- a/core/drand/protobuf/api.proto
+++ b/core/drand/protobuf/api.proto
@@ -1,7 +1,5 @@
 /*
- * This protobuf file contains the definition of the public API endpoints as
- * well as messages. All client implementations should use this reference
- * protobuf to implement a compatible drand client.
+ * Protobuf file containing empty message definition
  */
 syntax = "proto3";
 
@@ -10,25 +8,19 @@ package drand;
 /*option go_package = "github.com/drand/drand/protobuf/drand";*/
 option go_package = "drand";
 
-message Empty {}
+message Empty {
 
+}
+// Identity holds the necessary information to contact a drand node
 message Identity {
   string address = 1;
   bytes key = 2;
   bool tls = 3;
 }
 
-// Node holds the information related to a server in a group that forms a drand
-// network
-message Node {
-  Identity public = 1;
-  uint32 index = 2;
-}
-
-// GroupPacket represents a group that is running a drand network (or is in the
-// process of creating one or performing a resharing).
+// GroupPacket represents a group
 message GroupPacket {
-  repeated Node nodes = 1;
+  repeated Identity nodes = 1;
   uint32 threshold = 2;
   // period in seconds
   uint32 period = 3;
@@ -37,8 +29,15 @@ message GroupPacket {
   bytes genesis_seed = 6;
   repeated bytes dist_key = 7;
 }
+message GroupRequest {
 
-message GroupRequest {}
+}
+
+/*
+ * This protobuf file contains the definition of the public API endpoints as
+ * well as messages. All client implementations should use this reference
+ * protobuf to implement a compatible drand client.
+ */
 
 service Public {
   // PublicRand is the method that returns the publicly verifiable randomness
@@ -55,8 +54,7 @@ service Public {
   // endpoint belongs to
   rpc Group(drand.GroupRequest) returns (drand.GroupPacket);
 
-  // DistKey returns the distributed key from which drand node endpoint get a
-  // share
+  // DistKey returns the distributed key from which drand node endpoint get a share
   rpc DistKey(DistKeyRequest) returns (DistKeyResponse);
 
   // Home is a simple endpoint
@@ -87,29 +85,41 @@ message PublicRandResponse {
 // PrivateRandRequest is the message to send when requesting a private random
 // value.
 message PrivateRandRequest {
-  // Request is the ECIES encryption of an ephemereal public key towards which
-  // to encrypt the private randomness. The format of the bytes is denoted by
-  // the ECIES encryption used by drand.
-  bytes request = 1;
+  // Request must contains a public key towards which to encrypt the private
+  // randomness.
+  ECIES request = 2;
 }
 
 message PrivateRandResponse {
-  // Responses is the ECIES encryption of the private randomness using the
-  // ephemereal public key sent in the request.  The format of the bytes is
-  // denoted by the ECIES  encryption used by drand.
-  bytes response = 1;
+  // Response contains the private randomness encrypted towards the client's
+  // request key.
+  ECIES response = 1;
 }
 
-// DistKeyRequest requests the distributed public key used during the randomness
-// generation process
-message DistKeyRequest {}
+message ECIES {
+  bytes ephemeral = 1;
+  bytes ciphertext = 2;
+  bytes nonce = 3;
+}
+
+// DistKeyRequest requests the distributed public key used during the randomness generation process
+message DistKeyRequest {
+}
 
 message DistKeyResponse {
   bytes key = 2;
 }
 
-message HomeRequest {}
+message HomeRequest {
+}
 
 message HomeResponse {
   string status = 1;
+}
+
+// Node represents the information about a drand's node
+message Node {
+  string address = 1;
+  string key = 2; // public key of the node
+  bool TLS = 3;
 }


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

Use drand v0.8.1 protobuf schema.
Update drand client and parser.
Update `drand_example`.