### PR TITLE
Voucher's signature

### DIFF
--- a/core/api/rpc/json.hpp
+++ b/core/api/rpc/json.hpp
@@ -956,7 +956,7 @@ namespace fc::api {
       Set(j, "Amount", v.amount);
       Set(j, "MinSettleHeight", v.min_close_height);
       Set(j, "Merges", v.merges);
-      Set(j, "Signature", v.signature);
+      Set(j, "SignatureBytes", v.signature_bytes);
       return j;
     }
 
@@ -971,7 +971,7 @@ namespace fc::api {
       decode(v.amount, Get(j, "Amount"));
       decode(v.min_close_height, Get(j, "MinSettleHeight"));
       decode(v.merges, Get(j, "Merges"));
-      decode(v.signature, Get(j, "Signature"));
+      decode(v.signature_bytes, Get(j, "SignatureBytes"));
     }
 
     ENCODE(HeadChange) {

--- a/core/crypto/signature/signature.cpp
+++ b/core/crypto/signature/signature.cpp
@@ -52,7 +52,7 @@ namespace fc::crypto::signature {
       }
       case BLS: {
         BlsSignature bls;
-        if (input.size() - 1 != bls.size()) {
+        if (input.size() != bls.size() + 1) {
           return SignatureError::kInvalidSignatureLength;
         }
         std::copy_n(std::make_move_iterator(std::next(input.begin())),
@@ -60,6 +60,19 @@ namespace fc::crypto::signature {
                     bls.begin());
         return bls;
       }
+    }
+    return SignatureError::kWrongSignatureType;
+  }
+
+  outcome::result<bool> Signature::isBls(const BytesIn &input) {
+    if (input.empty()) {
+      return SignatureError::kWrongSignatureType;
+    }
+    switch (input[0]) {
+      case SECP256K1:
+        return false;
+      case BLS:
+        return true;
     }
     return SignatureError::kWrongSignatureType;
   }

--- a/core/crypto/signature/signature.hpp
+++ b/core/crypto/signature/signature.hpp
@@ -49,6 +49,7 @@ namespace fc::crypto::signature {
 
     Buffer toBytes() const;
     static outcome::result<Signature> fromBytes(BytesIn input);
+    static outcome::result<bool> isBls(const BytesIn &input);
   };
 
   CBOR_ENCODE(Signature, signature) {

--- a/core/payment_channel_manager/impl/payment_channel_manager_impl.cpp
+++ b/core/payment_channel_manager/impl/payment_channel_manager_impl.cpp
@@ -24,6 +24,7 @@ namespace fc::payment_channel_manager {
   using vm::message::kDefaultGasPrice;
   using vm::message::UnsignedMessage;
   using vm::state::StateTreeImpl;
+  using crypto::signature::Signature;
   using InitActorExec = vm::actor::builtin::v0::init::Exec;
   using PaymentChannelConstruct =
       vm::actor::builtin::v0::payment_channel::Construct;
@@ -80,7 +81,7 @@ namespace fc::payment_channel_manager {
     OUTCOME_TRY(
         signature,
         api_->WalletSign(lookup_channel->second.control, voucher_bytes));
-    new_voucher.signature = signature;
+    new_voucher.signature_bytes = signature.toBytes();
 
     OUTCOME_TRY(validateVoucher(channel_address, new_voucher));
     lookup_channel->second.lanes[lane].push_back(new_voucher);
@@ -125,16 +126,17 @@ namespace fc::payment_channel_manager {
                 loadPaymentChannelActorState(channel_address));
 
     // check signature
-    if (!voucher.signature.has_value()) {
+    auto signature = Signature::fromBytes(voucher.signature_bytes.get());
+    if (!signature) {
       return PaymentChannelManagerError::kWrongSignature;
     }
     auto voucher_to_verify = voucher;
-    voucher_to_verify.signature = boost::none;
+    voucher_to_verify.signature_bytes = boost::none;
     OUTCOME_TRY(bytes_to_verify, codec::cbor::encode(voucher_to_verify));
     OUTCOME_TRY(verified,
                 api_->WalletVerify(payment_channel_actor_state.from,
                                    bytes_to_verify,
-                                   voucher.signature.get()));
+                                   signature.value()));
     if (!verified) {
       return PaymentChannelManagerError::kWrongSignature;
     }

--- a/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor.cpp
+++ b/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor.cpp
@@ -7,6 +7,7 @@
 #include "vm/actor/builtin/v0/codes.hpp"
 
 namespace fc::vm::actor::builtin::v0::payment_channel {
+  using crypto::signature::Signature;
   using primitives::address::Protocol;
 
   outcome::result<Address> resolveAccount(Runtime &runtime,
@@ -46,20 +47,20 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
 
   ACTOR_METHOD_IMPL(UpdateChannelState) {
     OUTCOME_TRY(readonly_state, assertCallerInChannel(runtime));
-    const auto &voucher = params.signed_voucher;
-    if (!voucher.signature) {
-      return VMExitCode::kErrIllegalArgument;
-    }
 
+    const auto &voucher = params.signed_voucher;
     auto voucher_signable = voucher;
-    voucher_signable.signature = boost::none;
+    voucher_signable.signature_bytes = boost::none;
     OUTCOME_TRY(voucher_signable_bytes, codec::cbor::encode(voucher_signable));
     auto &signer = runtime.getImmediateCaller() != readonly_state.to
                        ? readonly_state.to
                        : readonly_state.from;
+
+    const Buffer signature_bytes =
+        voucher.signature_bytes ? voucher.signature_bytes.get() : Buffer{};
     OUTCOME_TRY(verified,
-                runtime.verifySignature(
-                    *voucher.signature, signer, voucher_signable_bytes));
+                runtime.verifySignatureBytes(
+                    signature_bytes, signer, voucher_signable_bytes));
     if (!verified) {
       return VMExitCode::kErrIllegalArgument;
     }

--- a/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_state.hpp
@@ -77,7 +77,7 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
     TokenAmount amount;
     ChainEpoch min_close_height{};
     std::vector<Merge> merges{};
-    boost::optional<Signature> signature;
+    boost::optional<Buffer> signature_bytes;
 
     inline bool operator==(const SignedVoucher &rhs) const {
       return channel == rhs.channel && time_lock_min == rhs.time_lock_min
@@ -85,7 +85,7 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
              && secret_preimage == rhs.secret_preimage && extra == rhs.extra
              && lane == rhs.lane && nonce == rhs.nonce && amount == rhs.amount
              && min_close_height == rhs.min_close_height && merges == rhs.merges
-             && signature == rhs.signature;
+             && signature_bytes == rhs.signature_bytes;
     }
   };
   CBOR_TUPLE(SignedVoucher,
@@ -99,7 +99,7 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
              amount,
              min_close_height,
              merges,
-             signature)
+             signature_bytes)
 
   struct PaymentVerifyParams {
     Buffer extra;

--- a/core/vm/actor/cgo/actors.cpp
+++ b/core/vm/actor/cgo/actors.cpp
@@ -229,10 +229,10 @@ namespace fc::vm::actor::cgo {
   }
 
   RUNTIME_METHOD(gocRtVerifySig) {
-    auto signature{Signature::fromBytes(arg.get<Buffer>())};
+    auto signature_bytes{arg.get<Buffer>()};
     auto address{arg.get<Address>()};
     auto data{arg.get<Buffer>()};
-    if (auto ok{rt->verifySignature(signature.value(), address, data)}) {
+    if (auto ok{rt->verifySignatureBytes(signature_bytes, address, data)}) {
       ret << kOk << ok.value();
     } else {
       ret << kFatal;

--- a/core/vm/runtime/CMakeLists.txt
+++ b/core/vm/runtime/CMakeLists.txt
@@ -20,4 +20,5 @@ target_link_libraries(runtime
     proofs
     secp256k1_provider
     tipset
+    signature
     )

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -213,7 +213,7 @@ namespace fc::vm::runtime {
       const Address &address,
       gsl::span<const uint8_t> data) {
     const auto bls = Signature::isBls(signature_bytes);
-    if (!bls) {
+    if (bls.has_error()) {
       return false;
     }
     OUTCOME_TRY(

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -51,7 +51,8 @@ namespace fc::vm::runtime {
       DomainSeparationTag tag,
       ChainEpoch epoch,
       gsl::span<const uint8_t> seed) const {
-    return execution_->env->randomness->getRandomnessFromBeacon(tag, epoch, seed);
+    return execution_->env->randomness->getRandomnessFromBeacon(
+        tag, epoch, seed);
   }
 
   Address RuntimeImpl::getImmediateCaller() const {
@@ -205,6 +206,32 @@ namespace fc::vm::runtime {
         std::make_shared<crypto::bls::BlsProviderImpl>(),
         std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>()}
         .verify(account, data, signature);
+  }
+
+  outcome::result<bool> RuntimeImpl::verifySignatureBytes(
+      const Buffer &signature_bytes,
+      const Address &address,
+      gsl::span<const uint8_t> data) {
+    const auto bls = Signature::isBls(signature_bytes);
+    if (!bls) {
+      return false;
+    }
+    OUTCOME_TRY(
+        chargeGas(execution_->env->pricelist.onVerifySignature(bls.value())));
+    OUTCOME_TRY(
+        account,
+        resolveKey(
+            *execution_->state_tree, execution_->charging_ipld, address));
+
+    const auto signature = Signature::fromBytes(signature_bytes);
+    if (!signature) {
+      return false;
+    }
+
+    return storage::keystore::InMemoryKeyStore{
+        std::make_shared<crypto::bls::BlsProviderImpl>(),
+        std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>()}
+        .verify(account, data, signature.value());
   }
 
   outcome::result<bool> RuntimeImpl::verifyPoSt(

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -98,6 +98,11 @@ namespace fc::vm::runtime {
         const Address &address,
         gsl::span<const uint8_t> data) override;
 
+    outcome::result<bool> verifySignatureBytes(
+        const Buffer &signature_bytes,
+        const Address &address,
+        gsl::span<const uint8_t> data) override;
+
     outcome::result<bool> verifyPoSt(const WindowPoStVerifyInfo &info) override;
 
     outcome::result<CID> computeUnsealedSectorCid(

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -138,7 +138,7 @@ namespace fc::vm::runtime {
      * @brief Deletes an actor in the state tree
      *
      * @param address - Address of actor that receives remaining balance
-     * 
+     *
      * May only be called by the actor itself
      */
     virtual outcome::result<void> deleteActor(const Address &address) = 0;
@@ -195,6 +195,11 @@ namespace fc::vm::runtime {
     /// Verify signature
     virtual outcome::result<bool> verifySignature(
         const Signature &signature,
+        const Address &address,
+        gsl::span<const uint8_t> data) = 0;
+
+    virtual outcome::result<bool> verifySignatureBytes(
+        const Buffer &signature_bytes,
         const Address &address,
         gsl::span<const uint8_t> data) = 0;
 

--- a/test/core/test_vectors/test.cpp
+++ b/test/core/test_vectors/test.cpp
@@ -256,25 +256,8 @@ auto search() {
           kCorpusRoot + "/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-9.json"
       };
 
-      // Skip tests that fail in Fuhon
-      // TODO (@wer1st) these tests should be enabled after FIL-260
-      // Problem: we have a class for Signature that is parsed and partially
-      // verified during CBOR parsing. In case when node gets wrong signature,
-      // the error returns at the beginning of some actor’s methods. On the
-      // contrary, Lotus doesn’t parse it until VerifySignature method and
-      // charges a gas before it. We need to have the same behaviour.
-      static std::vector<std::string> fail_in_fuhon{
-          kCorpusRoot + "/msg_application/actor_exec--msg-apply-fail-actor-execution-illegal-arg--genesis.json",
-          kCorpusRoot + "/msg_application/actor_exec--msg-apply-fail-actor-execution-illegal-arg--actorsv2.json"
-      };
-
       if (std::find(fail_in_lotus.cbegin(), fail_in_lotus.cend(), path.string())
           != fail_in_lotus.cend()) {
-        continue;
-      }
-
-      if (std::find(fail_in_fuhon.cbegin(), fail_in_fuhon.cend(), path.string())
-          != fail_in_fuhon.cend()) {
         continue;
       }
 

--- a/test/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_test.cpp
@@ -22,6 +22,7 @@ namespace PaymentChannel = fc::vm::actor::builtin::v0::payment_channel;
 using fc::common::Buffer;
 using fc::crypto::blake2b::blake2b_256;
 using fc::crypto::signature::Secp256k1Signature;
+using fc::crypto::signature::Signature;
 using fc::primitives::ChainEpoch;
 using fc::primitives::TokenAmount;
 using fc::primitives::address::Address;
@@ -169,14 +170,16 @@ PaymentChannelActorTest::setupUpdateChannelState() {
   PaymentChannel::SignedVoucher voucher;
   caller = from_address;
   voucher.channel = actor_address;
-  voucher.signature = Secp256k1Signature{};
-  const auto &sig = *voucher.signature;
+  voucher.signature_bytes = Signature{Secp256k1Signature{}}.toBytes();
   ON_CALL_3(runtime,
-            verifySignature(sig, testing::_, testing::_),
+            verifySignatureBytes(
+                voucher.signature_bytes.get(), testing::_, testing::_),
             fc::outcome::success(true));
-  ON_CALL_3(runtime,
-            verifySignature(testing::Not(sig), testing::_, testing::_),
-            fc::outcome::success(false));
+  ON_CALL_3(
+      runtime,
+      verifySignatureBytes(
+          testing::Not(voucher.signature_bytes.get()), testing::_, testing::_),
+      fc::outcome::success(false));
   voucher.time_lock_min = epoch;
   voucher.time_lock_max = epoch;
   voucher.lane = 100;
@@ -188,7 +191,7 @@ PaymentChannelActorTest::setupUpdateChannelState() {
 /// PaymentChannelActor UpdateChannelState error: voucher has no signature
 TEST_F(PaymentChannelActorTest, UpdateChannelStateNoSignature) {
   auto voucher = setupUpdateChannelState();
-  voucher.signature = boost::none;
+  voucher.signature_bytes = boost::none;
 
   EXPECT_OUTCOME_ERROR(
       VMExitCode::kErrIllegalArgument,
@@ -198,7 +201,7 @@ TEST_F(PaymentChannelActorTest, UpdateChannelStateNoSignature) {
 /// PaymentChannelActor UpdateChannelState error: invalid voucher signature
 TEST_F(PaymentChannelActorTest, UpdateChannelStateSignatureNotVerified) {
   auto voucher = setupUpdateChannelState();
-  voucher.signature = Secp256k1Signature{1};
+  voucher.signature_bytes = Signature{Secp256k1Signature{1}}.toBytes();
 
   EXPECT_OUTCOME_ERROR(
       VMExitCode::kErrIllegalArgument,

--- a/test/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_test.cpp
@@ -22,6 +22,7 @@ namespace PaymentChannel = fc::vm::actor::builtin::v3::payment_channel;
 using fc::common::Buffer;
 using fc::crypto::blake2b::blake2b_256;
 using fc::crypto::signature::Secp256k1Signature;
+using fc::crypto::signature::Signature;
 using fc::primitives::ChainEpoch;
 using fc::primitives::TokenAmount;
 using fc::primitives::address::Address;
@@ -169,14 +170,16 @@ PaymentChannelActorTest::setupUpdateChannelState() {
   PaymentChannel::SignedVoucher voucher;
   caller = from_address;
   voucher.channel = actor_address;
-  voucher.signature = Secp256k1Signature{};
-  const auto &sig = *voucher.signature;
+  voucher.signature_bytes = Signature{Secp256k1Signature{}}.toBytes();
   ON_CALL_3(runtime,
-            verifySignature(sig, testing::_, testing::_),
+            verifySignatureBytes(
+                voucher.signature_bytes.get(), testing::_, testing::_),
             fc::outcome::success(true));
-  ON_CALL_3(runtime,
-            verifySignature(testing::Not(sig), testing::_, testing::_),
-            fc::outcome::success(false));
+  ON_CALL_3(
+      runtime,
+      verifySignatureBytes(
+          testing::Not(voucher.signature_bytes.get()), testing::_, testing::_),
+      fc::outcome::success(false));
   voucher.time_lock_min = epoch;
   voucher.time_lock_max = epoch;
   voucher.lane = 100;
@@ -188,7 +191,7 @@ PaymentChannelActorTest::setupUpdateChannelState() {
 /// PaymentChannelActor UpdateChannelState error: voucher has no signature
 TEST_F(PaymentChannelActorTest, UpdateChannelStateNoSignature) {
   auto voucher = setupUpdateChannelState();
-  voucher.signature = boost::none;
+  voucher.signature_bytes = boost::none;
 
   EXPECT_OUTCOME_ERROR(
       VMExitCode::kErrIllegalArgument,
@@ -198,7 +201,7 @@ TEST_F(PaymentChannelActorTest, UpdateChannelStateNoSignature) {
 /// PaymentChannelActor UpdateChannelState error: invalid voucher signature
 TEST_F(PaymentChannelActorTest, UpdateChannelStateSignatureNotVerified) {
   auto voucher = setupUpdateChannelState();
-  voucher.signature = Secp256k1Signature{1};
+  voucher.signature_bytes = Signature{Secp256k1Signature{1}}.toBytes();
 
   EXPECT_OUTCOME_ERROR(
       VMExitCode::kErrIllegalArgument,

--- a/test/testutil/mocks/vm/runtime/runtime_mock.hpp
+++ b/test/testutil/mocks/vm/runtime/runtime_mock.hpp
@@ -84,6 +84,11 @@ namespace fc::vm::runtime {
                                        const Address &address,
                                        gsl::span<const uint8_t> data));
 
+    MOCK_METHOD3(verifySignatureBytes,
+                 outcome::result<bool>(const Buffer &signature_bytes,
+                                       const Address &address,
+                                       gsl::span<const uint8_t> data));
+
     MOCK_METHOD1(verifyPoSt,
                  outcome::result<bool>(const WindowPoStVerifyInfo &info));
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Use buffer instead of Signature in Signed Voucher.
Enable 2 test vectors that were blocked by this issue.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Delayed Signature parsing that allows to charge gas before VerifySignature() and have the same behaviour as Lotus
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
