### PR TITLE
Verify consensus fault

### DIFF
--- a/core/api/make.cpp
+++ b/core/api/make.cpp
@@ -21,6 +21,7 @@
 #include "vm/actor/builtin/v0/miner/types.hpp"
 #include "vm/actor/builtin/v0/storage_power/storage_power_actor_state.hpp"
 #include "vm/actor/impl/invoker_impl.hpp"
+#include "vm/interpreter/interpreter.hpp"
 #include "vm/message/impl/message_signer_impl.hpp"
 #include "vm/runtime/env.hpp"
 #include "vm/runtime/impl/tipset_randomness.hpp"
@@ -63,8 +64,6 @@ namespace fc::api {
                ? !claim_qa.is_zero()
                : claim_qa > kConsensusMinerMinPower;
   }
-
-  constexpr EpochDuration kWinningPoStSectorSetLookback{10};
 
   void beaconEntriesForBlock(const DrandSchedule &schedule,
                              Beaconizer &beaconizer,
@@ -164,16 +163,17 @@ namespace fc::api {
       std::shared_ptr<ChainStore> chain_store,
       const std::string &network_name,
       std::shared_ptr<WeightCalculator> weight_calculator,
-      TsLoadPtr ts_load,
+      const Env0 &env0,
       TsBranchPtr ts_main,
-      std::shared_ptr<Ipld> ipld,
       std::shared_ptr<Mpool> mpool,
-      std::shared_ptr<Interpreter> interpreter,
       std::shared_ptr<MsgWaiter> msg_waiter,
       std::shared_ptr<Beaconizer> beaconizer,
       std::shared_ptr<DrandSchedule> drand_schedule,
       std::shared_ptr<PubSub> pubsub,
       std::shared_ptr<KeyStore> key_store) {
+    auto ts_load{env0.ts_load};
+    auto ipld{env0.ipld};
+    auto interpreter_cache{env0.interpreter_cache};
     auto tipsetContext = [=](const TipsetKey &tipset_key,
                              bool interpret =
                                  false) -> outcome::result<TipsetContext> {
@@ -185,31 +185,11 @@ namespace fc::api {
       }
       TipsetContext context{tipset, {ipld, tipset->getParentStateRoot()}, {}};
       if (interpret) {
-        OUTCOME_TRY(result, interpreter->getCached(tipset->key));
+        OUTCOME_TRY(result, interpreter_cache->get(tipset->key));
         context.state_tree = {ipld, result.state_root};
         context.interpreted = result;
       }
       return context;
-    };
-    auto getLookbackTipSetForRound =
-        [=](auto tipset,
-            auto ts_branch,
-            auto epoch) -> outcome::result<TipsetContext> {
-      auto lookback{
-          std::max(ChainEpoch{0}, epoch - kWinningPoStSectorSetLookback)};
-      if (vm::version::getNetworkVersion(tipset->height())
-          > vm::version::NetworkVersion::kVersion3) {
-        lookback =
-            std::max(ChainEpoch{0},
-                     epoch - vm::actor::builtin::v0::miner::kChainFinalityish);
-      }
-      if (lookback < tipset->epoch()) {
-        OUTCOME_TRY(it, find(ts_branch, lookback));
-        OUTCOME_TRYA(tipset, ts_load->loadw(it.second->second));
-      }
-      OUTCOME_TRY(result, interpreter->getCached(tipset->key));
-      return TipsetContext{
-          std::move(tipset), {ipld, std::move(result.state_root)}, {}};
     };
 
     auto api = std::make_shared<FullNodeApi>();
@@ -354,7 +334,7 @@ namespace fc::api {
       OUTCOME_TRY(miner_state, context.minerState(t.miner));
       OUTCOME_TRY(block,
                   blockchain::production::generate(
-                      *interpreter, ts_load, ipld, std::move(t)));
+                      *interpreter_cache, ts_load, ipld, std::move(t)));
 
       OUTCOME_TRY(block_signable, codec::cbor::encode(block.header));
       OUTCOME_TRY(minfo, miner_state.info.get());
@@ -380,9 +360,11 @@ namespace fc::api {
           MiningBaseInfo info;
           OUTCOME_CB(auto ts_branch,
                      TsBranch::make(ts_load, tipset_key, ts_main));
-          OUTCOME_CB(
-              info.prev_beacon,
-              latestBeacon(ts_load, ts_branch, context.tipset->height()));
+          OUTCOME_CB(auto it, find(ts_branch, context.tipset->height()));
+          OUTCOME_CB(info.prev_beacon, latestBeacon(ts_load, it));
+          OUTCOME_CB(auto it2, getLookbackTipSetForRound(it, epoch));
+          OUTCOME_CB(auto cached,
+                     interpreter_cache->get(it2.second->second.key));
           auto prev{info.prev_beacon.round};
           beaconEntriesForBlock(
               *drand_schedule,
@@ -391,9 +373,8 @@ namespace fc::api {
               prev,
               [=, MOVE(cb), MOVE(context), MOVE(info)](auto _beacons) mutable {
                 OUTCOME_CB(info.beacons, _beacons);
-                OUTCOME_CB(auto lookback,
-                           getLookbackTipSetForRound(
-                               context.tipset, ts_branch, epoch));
+                TipsetContext lookback{
+                    nullptr, {ipld, std::move(cached.state_root)}, {}};
                 OUTCOME_CB(auto state, lookback.minerState(miner));
                 OUTCOME_CB(auto seed, codec::cbor::encode(miner));
                 auto post_rand{crypto::randomness::drawRandomness(
@@ -473,11 +454,7 @@ namespace fc::api {
           OUTCOME_TRY(ts_branch, TsBranch::make(ts_load, tipset_key, ts_main));
 
           auto randomness = std::make_shared<TipsetRandomness>(ts_load);
-          auto env = std::make_shared<Env>(std::make_shared<InvokerImpl>(),
-                                           randomness,
-                                           ipld,
-                                           ts_branch,
-                                           context.tipset);
+          auto env = std::make_shared<Env>(env0, ts_branch, context.tipset);
           InvocResult result;
           result.message = message;
           OUTCOME_TRYA(result.receipt, env->applyImplicitMessage(message));

--- a/core/api/make.hpp
+++ b/core/api/make.hpp
@@ -15,7 +15,7 @@
 #include "storage/chain/msg_waiter.hpp"
 #include "storage/keystore/keystore.hpp"
 #include "storage/mpool/mpool.hpp"
-#include "vm/interpreter/interpreter.hpp"
+#include "vm/runtime/env0.hpp"
 
 namespace fc::api {
   using blockchain::weight::WeightCalculator;
@@ -27,7 +27,7 @@ namespace fc::api {
   using storage::blockchain::MsgWaiter;
   using storage::keystore::KeyStore;
   using storage::mpool::Mpool;
-  using vm::interpreter::Interpreter;
+  using vm::runtime::Env0;
   using Logger = common::Logger;
 
   outcome::result<IpldObject> getNode(std::shared_ptr<Ipld> ipld,
@@ -38,11 +38,9 @@ namespace fc::api {
       std::shared_ptr<ChainStore> chain_store,
       const std::string &network_name,
       std::shared_ptr<WeightCalculator> weight_calculator,
-      TsLoadPtr ts_load,
+      const Env0 &env0,
       TsBranchPtr ts_main,
-      std::shared_ptr<Ipld> ipld,
       std::shared_ptr<Mpool> mpool,
-      std::shared_ptr<Interpreter> interpreter,
       std::shared_ptr<MsgWaiter> msg_waiter,
       std::shared_ptr<Beaconizer> beaconizer,
       std::shared_ptr<DrandSchedule> drand_schedule,

--- a/core/api/make.hpp
+++ b/core/api/make.hpp
@@ -15,7 +15,7 @@
 #include "storage/chain/msg_waiter.hpp"
 #include "storage/keystore/keystore.hpp"
 #include "storage/mpool/mpool.hpp"
-#include "vm/runtime/env0.hpp"
+#include "vm/runtime/env_context.hpp"
 
 namespace fc::api {
   using blockchain::weight::WeightCalculator;
@@ -27,7 +27,7 @@ namespace fc::api {
   using storage::blockchain::MsgWaiter;
   using storage::keystore::KeyStore;
   using storage::mpool::Mpool;
-  using vm::runtime::Env0;
+  using vm::runtime::EnvironmentContext;
   using Logger = common::Logger;
 
   outcome::result<IpldObject> getNode(std::shared_ptr<Ipld> ipld,
@@ -38,7 +38,7 @@ namespace fc::api {
       std::shared_ptr<ChainStore> chain_store,
       const std::string &network_name,
       std::shared_ptr<WeightCalculator> weight_calculator,
-      const Env0 &env0,
+      const EnvironmentContext &env_context,
       TsBranchPtr ts_main,
       std::shared_ptr<Mpool> mpool,
       std::shared_ptr<MsgWaiter> msg_waiter,

--- a/core/blockchain/block_validator/impl/block_validator_impl.cpp
+++ b/core/blockchain/block_validator/impl/block_validator_impl.cpp
@@ -140,7 +140,7 @@ namespace fc::blockchain::block_validator {
   outcome::result<void> BlockValidatorImpl::stateTree(
       const BlockHeader &block) const {
     OUTCOME_TRY(parent_tipset, getParentTipset(block));
-    OUTCOME_TRY(result, vm_interpreter_->getCached(parent_tipset.get()->key));
+    OUTCOME_TRY(result, interpreter_cache_->get(parent_tipset.get()->key));
     if (result.state_root == block.parent_state_root
         && result.message_receipts == block.parent_message_receipts) {
       return outcome::success();

--- a/core/blockchain/block_validator/impl/block_validator_impl.hpp
+++ b/core/blockchain/block_validator/impl/block_validator_impl.hpp
@@ -33,7 +33,7 @@ namespace fc::blockchain::block_validator {
     using PowerTable = power::PowerTable;
     using BlsProvider = crypto::bls::BlsProvider;
     using SecpProvider = crypto::secp256k1::Secp256k1ProviderDefault;
-    using Interpreter = vm::interpreter::Interpreter;
+    using InterpreterCache = vm::interpreter::InterpreterCache;
     using Tipset = primitives::tipset::Tipset;
     using TipsetCPtr = primitives::tipset::TipsetCPtr;
 
@@ -48,7 +48,7 @@ namespace fc::blockchain::block_validator {
                        std::shared_ptr<PowerTable> power_table,
                        std::shared_ptr<BlsProvider> bls_crypto_provider,
                        std::shared_ptr<SecpProvider> secp_crypto_provider,
-                       std::shared_ptr<Interpreter> vm_interpreter)
+                       std::shared_ptr<InterpreterCache> interpreter_cache)
         : datastore_{std::move(ipfs_store)},
           clock_{std::move(utc_clock)},
           epoch_clock_{std::move(epoch_clock)},
@@ -56,7 +56,7 @@ namespace fc::blockchain::block_validator {
           power_table_{std::move(power_table)},
           bls_provider_{std::move(bls_crypto_provider)},
           secp_provider_{std::move(secp_crypto_provider)},
-          vm_interpreter_{std::move(vm_interpreter)} {}
+          interpreter_cache_{std::move(interpreter_cache)} {}
 
     outcome::result<void> validateBlock(
         const BlockHeader &header, scenarios::Scenario scenario) const override;
@@ -71,7 +71,7 @@ namespace fc::blockchain::block_validator {
     std::shared_ptr<PowerTable> power_table_;
     std::shared_ptr<BlsProvider> bls_provider_;
     std::shared_ptr<SecpProvider> secp_provider_;
-    std::shared_ptr<Interpreter> vm_interpreter_;
+    std::shared_ptr<InterpreterCache> interpreter_cache_;
 
     /**
      * BlockHeader CID -> Parent tipset

--- a/core/blockchain/production/block_producer.hpp
+++ b/core/blockchain/production/block_producer.hpp
@@ -4,17 +4,18 @@
  */
 
 #include "fwd.hpp"
-#include "vm/interpreter/interpreter.hpp"
+#include "primitives/block/block.hpp"
 
 namespace fc::blockchain::production {
   using primitives::block::BlockTemplate;
   using primitives::block::BlockWithMessages;
-  using vm::interpreter::Interpreter;
+  using vm::interpreter::InterpreterCache;
 
   constexpr size_t kBlockMaxMessagesCount = 1000;
 
-  outcome::result<BlockWithMessages> generate(Interpreter &interpreter,
-                                              TsLoadPtr ts_load,
-                                              std::shared_ptr<Ipld> ipld,
-                                              BlockTemplate t);
+  outcome::result<BlockWithMessages> generate(
+      InterpreterCache &interpreter_cache,
+      TsLoadPtr ts_load,
+      std::shared_ptr<Ipld> ipld,
+      BlockTemplate t);
 }  // namespace fc::blockchain::production

--- a/core/fwd.hpp
+++ b/core/fwd.hpp
@@ -137,13 +137,17 @@ namespace fc {
   }      // namespace storage
 
   namespace vm {
+    struct Circulating;
+
     namespace actor {
       struct Actor;
+      class Invoker;
     }  // namespace actor
 
     namespace interpreter {
       class CachedInterpreter;
       class Interpreter;
+      struct InterpreterCache;
       class InterpreterImpl;
     }  // namespace interpreter
 
@@ -156,6 +160,7 @@ namespace fc {
       struct Execution;
       struct MessageReceipt;
       class Runtime;
+      class RuntimeRandomness;
     }  // namespace runtime
 
     namespace state {

--- a/core/primitives/tipset/chain.cpp
+++ b/core/primitives/tipset/chain.cpp
@@ -368,8 +368,8 @@ namespace fc::primitives::tipset::chain {
 
   outcome::result<TsBranchIter> getLookbackTipSetForRound(TsBranchIter it,
                                                           ChainEpoch epoch) {
-    constexpr ChainEpoch kWinningPoStSectorSetLookback{10};
-    Height lookback = std::max<ChainEpoch>(
+    static constexpr ChainEpoch kWinningPoStSectorSetLookback{10};
+    const Height lookback = std::max<ChainEpoch>(
         0,
         epoch
             - (vm::version::getNetworkVersion(epoch)

--- a/core/primitives/tipset/chain.hpp
+++ b/core/primitives/tipset/chain.hpp
@@ -62,7 +62,8 @@ namespace fc::primitives::tipset::chain {
                                      Height height,
                                      bool allow_less = true);
 
-  outcome::result<BeaconEntry> latestBeacon(TsLoadPtr ts_load,
-                                            TsBranchPtr branch,
-                                            Height height);
+  outcome::result<BeaconEntry> latestBeacon(TsLoadPtr ts_load, TsBranchIter it);
+
+  outcome::result<TsBranchIter> getLookbackTipSetForRound(TsBranchIter it,
+                                                          ChainEpoch epoch);
 }  // namespace fc::primitives::tipset::chain

--- a/core/storage/keystore/CMakeLists.txt
+++ b/core/storage/keystore/CMakeLists.txt
@@ -12,5 +12,6 @@ target_link_libraries(keystore
     bls_provider
     filestore
     outcome
+    secp256k1_provider
     signature
     )

--- a/core/storage/keystore/impl/in_memory/in_memory_keystore.cpp
+++ b/core/storage/keystore/impl/in_memory/in_memory_keystore.cpp
@@ -5,53 +5,56 @@
 
 #include "storage/keystore/impl/in_memory/in_memory_keystore.hpp"
 
-#include <boost/foreach.hpp>
+#include "crypto/bls/impl/bls_provider_impl.hpp"
+#include "crypto/secp256k1/impl/secp256k1_provider_impl.hpp"
 
-using fc::primitives::address::Address;
-using fc::storage::keystore::InMemoryKeyStore;
-using fc::storage::keystore::KeyStore;
-using fc::storage::keystore::KeyStoreError;
+namespace fc::storage::keystore {
+  InMemoryKeyStore::InMemoryKeyStore(
+      std::shared_ptr<BlsProvider> blsProvider,
+      std::shared_ptr<Secp256k1ProviderDefault> secp256K1Provider)
+      : KeyStore(std::move(blsProvider), std::move(secp256K1Provider)) {}
 
-InMemoryKeyStore::InMemoryKeyStore(
-    std::shared_ptr<BlsProvider> blsProvider,
-    std::shared_ptr<Secp256k1ProviderDefault> secp256K1Provider)
-    : KeyStore(std::move(blsProvider), std::move(secp256K1Provider)) {}
-
-fc::outcome::result<bool> InMemoryKeyStore::has(const Address &address) const
-    noexcept {
-  return storage_.find(address) != storage_.end();
-}
-
-fc::outcome::result<void> InMemoryKeyStore::put(
-    Address address, typename KeyStore::TPrivateKey key) noexcept {
-  OUTCOME_TRY(valid, checkAddress(address, key));
-  if (!valid) return KeyStoreError::kWrongAddress;
-  auto res = storage_.try_emplace(address, key);
-  if (!res.second) return KeyStoreError::kAlreadyExists;
-
-  return fc::outcome::success();
-}
-
-fc::outcome::result<void> InMemoryKeyStore::remove(
-    const Address &address) noexcept {
-  OUTCOME_TRY(found, has(address));
-  if (!found) return KeyStoreError::kNotFound;
-  storage_.erase(address);
-  return fc::outcome::success();
-}
-
-fc::outcome::result<std::vector<Address>> InMemoryKeyStore::list() const
-    noexcept {
-  std::vector<Address> res;
-  for (auto &it : storage_) {
-    res.push_back(it.first);
+  outcome::result<bool> InMemoryKeyStore::has(const Address &address) const
+      noexcept {
+    return storage_.find(address) != storage_.end();
   }
-  return std::move(res);
-}
 
-fc::outcome::result<typename KeyStore::TPrivateKey> InMemoryKeyStore::get(
-    const Address &address) const noexcept {
-  OUTCOME_TRY(found, has(address));
-  if (!found) return KeyStoreError::kNotFound;
-  return storage_.at(address);
-}
+  outcome::result<void> InMemoryKeyStore::put(
+      Address address, typename KeyStore::TPrivateKey key) noexcept {
+    OUTCOME_TRY(valid, checkAddress(address, key));
+    if (!valid) return KeyStoreError::kWrongAddress;
+    auto res = storage_.try_emplace(address, key);
+    if (!res.second) return KeyStoreError::kAlreadyExists;
+
+    return outcome::success();
+  }
+
+  outcome::result<void> InMemoryKeyStore::remove(
+      const Address &address) noexcept {
+    OUTCOME_TRY(found, has(address));
+    if (!found) return KeyStoreError::kNotFound;
+    storage_.erase(address);
+    return outcome::success();
+  }
+
+  outcome::result<std::vector<Address>> InMemoryKeyStore::list() const
+      noexcept {
+    std::vector<Address> res;
+    for (auto &it : storage_) {
+      res.push_back(it.first);
+    }
+    return std::move(res);
+  }
+
+  outcome::result<typename KeyStore::TPrivateKey> InMemoryKeyStore::get(
+      const Address &address) const noexcept {
+    OUTCOME_TRY(found, has(address));
+    if (!found) return KeyStoreError::kNotFound;
+    return storage_.at(address);
+  }
+
+  const std::shared_ptr<KeyStore> kDefaultKeystore{
+      std::make_shared<InMemoryKeyStore>(
+          std::make_shared<crypto::bls::BlsProviderImpl>(),
+          std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>())};
+}  // namespace fc::storage::keystore

--- a/core/storage/keystore/keystore.hpp
+++ b/core/storage/keystore/keystore.hpp
@@ -116,6 +116,7 @@ namespace fc::storage::keystore {
     std::shared_ptr<Secp256k1ProviderDefault> secp256k1_provider_;
   };
 
+  extern const std::shared_ptr<KeyStore> kDefaultKeystore;
 }  // namespace fc::storage::keystore
 
 #endif  // FILECOIN_CORE_STORAGE_KEYSTORE_HPP

--- a/core/storage/mpool/mpool.cpp
+++ b/core/storage/mpool/mpool.cpp
@@ -9,26 +9,21 @@
 #include "primitives/tipset/chain.hpp"
 #include "vm/interpreter/interpreter.hpp"
 #include "vm/runtime/env.hpp"
-#include "vm/runtime/impl/tipset_randomness.hpp"
 #include "vm/state/impl/state_tree_impl.hpp"
 
 namespace fc::storage::mpool {
   using primitives::block::MsgMeta;
   using primitives::tipset::HeadChangeType;
   using vm::message::UnsignedMessage;
-  using vm::runtime::TipsetRandomness;
 
   std::shared_ptr<Mpool> Mpool::create(
-      TsLoadPtr ts_load,
+      const Env0 &env0,
       TsBranchPtr ts_main,
-      IpldPtr ipld,
-      std::shared_ptr<Interpreter> interpreter,
       std::shared_ptr<ChainStore> chain_store) {
     auto mpool{std::make_shared<Mpool>()};
-    mpool->ts_load = std::move(ts_load);
+    mpool->env0 = env0;
     mpool->ts_main = std::move(ts_main);
-    mpool->ipld = std::move(ipld);
-    mpool->interpreter = std::move(interpreter);
+    mpool->ipld = env0.ipld;
     mpool->head_sub = chain_store->subscribeHeadChanges([=](auto &change) {
       auto res{mpool->onHeadChange(change)};
       if (!res) {
@@ -51,7 +46,7 @@ namespace fc::storage::mpool {
   }
 
   outcome::result<uint64_t> Mpool::nonce(const Address &from) const {
-    OUTCOME_TRY(interpeted, interpreter->getCached(head->key));
+    OUTCOME_TRY(interpeted, env0.interpreter_cache->get(head->key));
     OUTCOME_TRY(
         actor, vm::state::StateTreeImpl{ipld, interpeted.state_root}.get(from));
     auto by_from_it{by_from.find(from)};
@@ -68,10 +63,8 @@ namespace fc::storage::mpool {
       msg.gas_limit = kBlockGasLimit;
       msg.gas_fee_cap = kMinimumBaseFee + 1;
       msg.gas_premium = 1;
-      OUTCOME_TRY(interpeted, interpreter->getCached(head->key));
-      auto randomness = std::make_shared<TipsetRandomness>(ts_load);
-      auto env{std::make_shared<vm::runtime::Env>(
-          nullptr, randomness, ipld, ts_main, head)};
+      OUTCOME_TRY(interpeted, env0.interpreter_cache->get(head->key));
+      auto env{std::make_shared<vm::runtime::Env>(env0, ts_main, head)};
       env->state_tree = std::make_shared<vm::state::StateTreeImpl>(
           ipld, interpeted.state_root);
       ++env->epoch;
@@ -161,7 +154,7 @@ namespace fc::storage::mpool {
       if (apply) {
         head = change.value;
       } else {
-        OUTCOME_TRYA(head, ts_load->load(change.value->getParents()));
+        OUTCOME_TRYA(head, env0.ts_load->load(change.value->getParents()));
       }
     }
     return outcome::success();

--- a/core/storage/mpool/mpool.hpp
+++ b/core/storage/mpool/mpool.hpp
@@ -9,6 +9,7 @@
 #include "fwd.hpp"
 #include "storage/chain/chain_store.hpp"
 #include "vm/message/message.hpp"
+#include "vm/runtime/env0.hpp"
 
 namespace fc::storage::mpool {
   using crypto::signature::Signature;
@@ -16,11 +17,11 @@ namespace fc::storage::mpool {
   using primitives::tipset::HeadChange;
   using primitives::tipset::Tipset;
   using storage::blockchain::ChainStore;
-  using vm::interpreter::Interpreter;
   using vm::message::SignedMessage;
   using vm::message::UnsignedMessage;
   using connection_t = boost::signals2::connection;
   using primitives::tipset::TipsetCPtr;
+  using vm::runtime::Env0;
 
   struct MpoolUpdate {
     enum class Type : int64_t { ADD, REMOVE };
@@ -37,10 +38,8 @@ namespace fc::storage::mpool {
     using Subscriber = void(const MpoolUpdate &);
 
     static std::shared_ptr<Mpool> create(
-        TsLoadPtr ts_load,
+        const Env0 &env0,
         TsBranchPtr ts_main,
-        IpldPtr ipld,
-        std::shared_ptr<Interpreter> interpreter,
         std::shared_ptr<ChainStore> chain_store);
     std::vector<SignedMessage> pending() const;
     outcome::result<uint64_t> nonce(const Address &from) const;
@@ -53,10 +52,9 @@ namespace fc::storage::mpool {
     }
 
    private:
-    TsLoadPtr ts_load;
+    Env0 env0;
     TsBranchPtr ts_main;
     IpldPtr ipld;
-    std::shared_ptr<Interpreter> interpreter;
     ChainStore::connection_t head_sub;
     TipsetCPtr head;
     std::map<Address, Pending> by_from;

--- a/core/storage/mpool/mpool.hpp
+++ b/core/storage/mpool/mpool.hpp
@@ -9,7 +9,7 @@
 #include "fwd.hpp"
 #include "storage/chain/chain_store.hpp"
 #include "vm/message/message.hpp"
-#include "vm/runtime/env0.hpp"
+#include "vm/runtime/env_context.hpp"
 
 namespace fc::storage::mpool {
   using crypto::signature::Signature;
@@ -21,7 +21,7 @@ namespace fc::storage::mpool {
   using vm::message::UnsignedMessage;
   using connection_t = boost::signals2::connection;
   using primitives::tipset::TipsetCPtr;
-  using vm::runtime::Env0;
+  using vm::runtime::EnvironmentContext;
 
   struct MpoolUpdate {
     enum class Type : int64_t { ADD, REMOVE };
@@ -38,7 +38,7 @@ namespace fc::storage::mpool {
     using Subscriber = void(const MpoolUpdate &);
 
     static std::shared_ptr<Mpool> create(
-        const Env0 &env0,
+        const EnvironmentContext &env_context,
         TsBranchPtr ts_main,
         std::shared_ptr<ChainStore> chain_store);
     std::vector<SignedMessage> pending() const;
@@ -52,7 +52,7 @@ namespace fc::storage::mpool {
     }
 
    private:
-    Env0 env0;
+    EnvironmentContext env_context;
     TsBranchPtr ts_main;
     IpldPtr ipld;
     ChainStore::connection_t head_sub;

--- a/core/vm/actor/cgo/actors.cpp
+++ b/core/vm/actor/cgo/actors.cpp
@@ -67,7 +67,7 @@ namespace fc::vm::actor::cgo {
 
   template <typename T>
   inline auto charge(CborEncodeStream &ret, const outcome::result<T> &r) {
-    if (!r && r.error() == VMExitCode::kSysErrOutOfGas) {
+    if (!r && r.error() == asAbort(VMExitCode::kSysErrOutOfGas)) {
       ret << VMExitCode::kSysErrOutOfGas;
       return true;
     }

--- a/core/vm/actor/cgo/actors.cpp
+++ b/core/vm/actor/cgo/actors.cpp
@@ -227,6 +227,22 @@ namespace fc::vm::actor::cgo {
     }
   }
 
+  RUNTIME_METHOD(gocRtVerifyConsensusFault) {
+    auto block1{arg.get<Buffer>()};
+    auto block2{arg.get<Buffer>()};
+    auto extra{arg.get<Buffer>()};
+    auto _fault{rt->verifyConsensusFault(block1, block2, extra)};
+    // TODO(turuslan): correct error handling
+    if (!charge(ret, _fault)) {
+      auto &fault{_fault.value()};
+      if (fault) {
+        ret << kOk << true << fault->target << fault->epoch << fault->type;
+      } else {
+        ret << kOk << false;
+      }
+    }
+  }
+
   RUNTIME_METHOD(gocRtCommD) {
     auto type{arg.get<RegisteredSealProof>()};
     auto pieces{arg.get<std::vector<PieceInfo>>()};

--- a/core/vm/actor/cgo/c_actors.h
+++ b/core/vm/actor/cgo/c_actors.h
@@ -22,6 +22,7 @@ Raw gocRtVerifySeals(Raw);
 Raw gocRtActorId(Raw);
 Raw gocRtSend(Raw);
 Raw gocRtVerifySig(Raw);
+Raw gocRtVerifyConsensusFault(Raw);
 Raw gocRtCommD(Raw);
 Raw gocRtNewAddress(Raw);
 Raw gocRtCreateActor(Raw);

--- a/core/vm/exit_code/exit_code.hpp
+++ b/core/vm/exit_code/exit_code.hpp
@@ -129,6 +129,7 @@ namespace fc::vm {
   bool isAbortExitCode(const std::error_code &error);
 
   outcome::result<VMExitCode> asExitCode(const std::error_code &error);
+  std::error_code catchAbort(const std::error_code &error);
 }  // namespace fc::vm
 
 OUTCOME_HPP_DECLARE_ERROR(fc::vm, VMExitCode);
@@ -138,6 +139,20 @@ OUTCOME_HPP_DECLARE_ERROR(fc::vm, VMFatal);
 OUTCOME_HPP_DECLARE_ERROR(fc::vm, VMAbortExitCode);
 
 namespace fc::vm {
+  template <typename T>
+  outcome::result<T> catchAbort(outcome::result<T> &&result) {
+    if (!result) {
+      return catchAbort(result.error());
+    }
+    return result;
+  }
+
+  template <typename T>
+  void catchAbort(outcome::result<T> &result) {
+    if (!result) {
+      result = catchAbort(result.error());
+    }
+  }
 
   template <typename T>
   outcome::result<VMExitCode> asExitCode(const outcome::result<T> &result) {

--- a/core/vm/exit_code/impl/exit_code.cpp
+++ b/core/vm/exit_code/impl/exit_code.cpp
@@ -42,4 +42,11 @@ namespace fc::vm {
     }
     return outcome::failure(error);
   }
+
+  std::error_code catchAbort(const std::error_code &error) {
+    if (isAbortExitCode(error)) {
+      return VMExitCode{error.value()};
+    }
+    return error;
+  }
 }  // namespace fc::vm

--- a/core/vm/interpreter/impl/interpreter_impl.cpp
+++ b/core/vm/interpreter/impl/interpreter_impl.cpp
@@ -58,7 +58,7 @@ namespace fc::vm::interpreter {
       const Key &key) const {
     boost::optional<outcome::result<Result>> result;
     if (kv->contains(key.key)) {
-      auto raw{kv->get(key.key).value()};
+      const auto raw{kv->get(key.key).value()};
       if (auto cached{
               codec::cbor::decode<boost::optional<Result>>(raw).value()}) {
         result.emplace(std::move(*cached));

--- a/core/vm/interpreter/impl/interpreter_impl.hpp
+++ b/core/vm/interpreter/impl/interpreter_impl.hpp
@@ -11,13 +11,13 @@
 #include "vm/actor/invoker.hpp"
 #include "vm/interpreter/interpreter.hpp"
 #include "vm/runtime/circulating.hpp"
-#include "vm/runtime/env0.hpp"
+#include "vm/runtime/env_context.hpp"
 #include "vm/runtime/runtime_randomness.hpp"
 #include "vm/runtime/runtime_types.hpp"
 
 namespace fc::vm::interpreter {
   using blockchain::weight::WeightCalculator;
-  using runtime::Env0;
+  using runtime::EnvironmentContext;
   using runtime::MessageReceipt;
   using runtime::RuntimeRandomness;
   using storage::PersistentBufferMap;
@@ -26,7 +26,7 @@ namespace fc::vm::interpreter {
 
   class InterpreterImpl : public Interpreter {
    public:
-    InterpreterImpl(const Env0 &env0,
+    InterpreterImpl(const EnvironmentContext &env_context,
                     std::shared_ptr<WeightCalculator> weight_calculator);
 
     outcome::result<Result> interpret(TsBranchPtr ts_branch,
@@ -43,7 +43,7 @@ namespace fc::vm::interpreter {
     bool hasDuplicateMiners(const std::vector<BlockHeader> &blocks) const;
     outcome::result<BigInt> getWeight(const TipsetCPtr &tipset) const;
 
-    Env0 env0_;
+    EnvironmentContext env_context_;
     std::shared_ptr<WeightCalculator> weight_calculator_;
   };
 

--- a/core/vm/interpreter/impl/interpreter_impl.hpp
+++ b/core/vm/interpreter/impl/interpreter_impl.hpp
@@ -11,11 +11,13 @@
 #include "vm/actor/invoker.hpp"
 #include "vm/interpreter/interpreter.hpp"
 #include "vm/runtime/circulating.hpp"
+#include "vm/runtime/env0.hpp"
 #include "vm/runtime/runtime_randomness.hpp"
 #include "vm/runtime/runtime_types.hpp"
 
 namespace fc::vm::interpreter {
   using blockchain::weight::WeightCalculator;
+  using runtime::Env0;
   using runtime::MessageReceipt;
   using runtime::RuntimeRandomness;
   using storage::PersistentBufferMap;
@@ -24,18 +26,13 @@ namespace fc::vm::interpreter {
 
   class InterpreterImpl : public Interpreter {
    public:
-    InterpreterImpl(std::shared_ptr<Invoker> invoker,
-                    TsLoadPtr ts_load,
-                    std::shared_ptr<WeightCalculator> weight_calculator,
-                    std::shared_ptr<RuntimeRandomness> randomness,
-                    std::shared_ptr<Circulating> circulating);
+    InterpreterImpl(const Env0 &env0,
+                    std::shared_ptr<WeightCalculator> weight_calculator);
 
     outcome::result<Result> interpret(TsBranchPtr ts_branch,
-                                      const IpldPtr &store,
                                       const TipsetCPtr &tipset) const override;
     outcome::result<Result> applyBlocks(
         TsBranchPtr ts_branch,
-        const IpldPtr &store,
         const TipsetCPtr &tipset,
         std::vector<MessageReceipt> *all_receipts) const;
 
@@ -46,27 +43,20 @@ namespace fc::vm::interpreter {
     bool hasDuplicateMiners(const std::vector<BlockHeader> &blocks) const;
     outcome::result<BigInt> getWeight(const TipsetCPtr &tipset) const;
 
-    std::shared_ptr<Invoker> invoker_;
-    TsLoadPtr ts_load;
+    Env0 env0_;
     std::shared_ptr<WeightCalculator> weight_calculator_;
-    std::shared_ptr<RuntimeRandomness> randomness_;
-    std::shared_ptr<Circulating> circulating_;
   };
 
   class CachedInterpreter : public Interpreter {
    public:
     CachedInterpreter(std::shared_ptr<Interpreter> interpreter,
-                      std::shared_ptr<PersistentBufferMap> store)
-        : interpreter{std::move(interpreter)}, store{std::move(store)} {}
+                      std::shared_ptr<InterpreterCache> cache);
     outcome::result<Result> interpret(TsBranchPtr ts_branch,
-                                      const IpldPtr &store,
                                       const TipsetCPtr &tipset) const override;
-    outcome::result<boost::optional<Result>> tryGetCached(
-        const TipsetKey &tsk) const override;
 
    private:
     std::shared_ptr<Interpreter> interpreter;
-    std::shared_ptr<PersistentBufferMap> store;
+    std::shared_ptr<InterpreterCache> cache;
   };
 }  // namespace fc::vm::interpreter
 

--- a/core/vm/runtime/CMakeLists.txt
+++ b/core/vm/runtime/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(runtime
     bls_provider
     cgo_actors
     dvm
+    interpreter
     ipfs_datastore_error
     ipld_traverser
     keystore

--- a/core/vm/runtime/CMakeLists.txt
+++ b/core/vm/runtime/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(runtime
 target_link_libraries(runtime
     actor
     blake2
-    bls_provider
     cgo_actors
     dvm
     interpreter
@@ -23,7 +22,6 @@ target_link_libraries(runtime
     keystore
     message
     proofs
-    secp256k1_provider
     tipset
     signature
     toolchain

--- a/core/vm/runtime/env.hpp
+++ b/core/vm/runtime/env.hpp
@@ -9,13 +9,13 @@
 #include "primitives/types.hpp"
 #include "vm/actor/invoker.hpp"
 #include "vm/runtime/circulating.hpp"
+#include "vm/runtime/env0.hpp"
 #include "vm/runtime/pricelist.hpp"
 #include "vm/runtime/runtime_randomness.hpp"
 #include "vm/state/impl/state_tree_impl.hpp"
 
 namespace fc::vm::runtime {
   using actor::Actor;
-  using actor::Invoker;
   using primitives::tipset::TipsetCPtr;
   using state::StateTree;
   using state::StateTreeImpl;
@@ -53,11 +53,7 @@ namespace fc::vm::runtime {
 
   /// Environment contains objects that are shared by runtime contexts
   struct Env : std::enable_shared_from_this<Env> {
-    Env(std::shared_ptr<Invoker> invoker,
-        std::shared_ptr<RuntimeRandomness> randomness,
-        IpldPtr ipld,
-        TsBranchPtr ts_branch,
-        TipsetCPtr tipset);
+    Env(const Env0 &env0, TsBranchPtr ts_branch, TipsetCPtr tipset);
 
     struct Apply {
       MessageReceipt receipt;
@@ -72,13 +68,11 @@ namespace fc::vm::runtime {
 
     std::shared_ptr<IpldBuffered> ipld;
     std::shared_ptr<StateTreeImpl> state_tree;
-    std::shared_ptr<Invoker> invoker;
-    std::shared_ptr<RuntimeRandomness> randomness;
+    Env0 env0;
     uint64_t epoch;  // mutable epoch for cron()
     TsBranchPtr ts_branch;
     TipsetCPtr tipset;
     Pricelist pricelist;
-    std::shared_ptr<Circulating> circulating;
   };
 
   struct Execution : std::enable_shared_from_this<Execution> {

--- a/core/vm/runtime/env.hpp
+++ b/core/vm/runtime/env.hpp
@@ -9,7 +9,7 @@
 #include "primitives/types.hpp"
 #include "vm/actor/invoker.hpp"
 #include "vm/runtime/circulating.hpp"
-#include "vm/runtime/env0.hpp"
+#include "vm/runtime/env_context.hpp"
 #include "vm/runtime/pricelist.hpp"
 #include "vm/runtime/runtime_randomness.hpp"
 #include "vm/state/impl/state_tree_impl.hpp"
@@ -53,7 +53,9 @@ namespace fc::vm::runtime {
 
   /// Environment contains objects that are shared by runtime contexts
   struct Env : std::enable_shared_from_this<Env> {
-    Env(const Env0 &env0, TsBranchPtr ts_branch, TipsetCPtr tipset);
+    Env(const EnvironmentContext &env_context,
+        TsBranchPtr ts_branch,
+        TipsetCPtr tipset);
 
     struct Apply {
       MessageReceipt receipt;
@@ -68,7 +70,7 @@ namespace fc::vm::runtime {
 
     std::shared_ptr<IpldBuffered> ipld;
     std::shared_ptr<StateTreeImpl> state_tree;
-    Env0 env0;
+    EnvironmentContext env_context;
     uint64_t epoch;  // mutable epoch for cron()
     TsBranchPtr ts_branch;
     TipsetCPtr tipset;

--- a/core/vm/runtime/env0.hpp
+++ b/core/vm/runtime/env0.hpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "fwd.hpp"
+
+namespace fc::vm::runtime {
+  using actor::Invoker;
+  using interpreter::InterpreterCache;
+
+  struct Env0 {
+    IpldPtr ipld;
+    std::shared_ptr<Invoker> invoker;
+    std::shared_ptr<RuntimeRandomness> randomness;
+    TsLoadPtr ts_load{};
+    std::shared_ptr<InterpreterCache> interpreter_cache{};
+    std::shared_ptr<Circulating> circulating{};
+  };
+}  // namespace fc::vm::runtime

--- a/core/vm/runtime/env_context.hpp
+++ b/core/vm/runtime/env_context.hpp
@@ -11,7 +11,7 @@ namespace fc::vm::runtime {
   using actor::Invoker;
   using interpreter::InterpreterCache;
 
-  struct Env0 {
+  struct EnvironmentContext {
     IpldPtr ipld;
     std::shared_ptr<Invoker> invoker;
     std::shared_ptr<RuntimeRandomness> randomness;

--- a/core/vm/runtime/impl/env.cpp
+++ b/core/vm/runtime/impl/env.cpp
@@ -122,16 +122,11 @@ namespace fc::vm::runtime {
     return shared_from_this();
   }
 
-  Env::Env(std::shared_ptr<Invoker> invoker,
-           std::shared_ptr<RuntimeRandomness> randomness,
-           IpldPtr ipld,
-           TsBranchPtr ts_branch,
-           TipsetCPtr tipset)
-      : ipld{std::make_shared<IpldBuffered>(std::move(ipld))},
+  Env::Env(const Env0 &env0, TsBranchPtr ts_branch, TipsetCPtr tipset)
+      : ipld{std::make_shared<IpldBuffered>(env0.ipld)},
         state_tree{std::make_shared<StateTreeImpl>(
             this->ipld, tipset->getParentStateRoot())},
-        invoker{std::move(invoker)},
-        randomness{std::move(randomness)},
+        env0{env0},
         epoch{tipset->height()},
         ts_branch{std::move(ts_branch)},
         tipset{std::move(tipset)} {
@@ -386,7 +381,7 @@ namespace fc::vm::runtime {
       _message.from = caller_id;
       auto runtime = std::make_shared<RuntimeImpl>(
           shared_from_this(), _message, caller_id);
-      auto result = env->invoker->invoke(to_actor, runtime);
+      auto result = env->env0.invoker->invoke(to_actor, runtime);
       catchAbort(result);
       return result;
     }

--- a/core/vm/runtime/impl/env.cpp
+++ b/core/vm/runtime/impl/env.cpp
@@ -235,10 +235,11 @@ namespace fc::vm::runtime {
     OUTCOME_TRY(add_locked(kRewardAddress, apply.reward));
     auto over{limit - 11 * used / 10};
     auto gas_burned{
-        used == 0  ? limit
-        : over < 0 ? 0
-                   : static_cast<GasAmount>(bigdiv(
-                       BigInt{limit - used} * std::min(used, over), used))};
+        used == 0
+            ? limit
+            : over < 0 ? 0
+                       : static_cast<GasAmount>(bigdiv(
+                           BigInt{limit - used} * std::min(used, over), used))};
     if (gas_burned != 0) {
       OUTCOME_TRY(add_locked(actor::kBurntFundsActorAddress,
                              base_fee_pay * gas_burned));

--- a/core/vm/runtime/impl/env.cpp
+++ b/core/vm/runtime/impl/env.cpp
@@ -122,11 +122,13 @@ namespace fc::vm::runtime {
     return shared_from_this();
   }
 
-  Env::Env(const Env0 &env0, TsBranchPtr ts_branch, TipsetCPtr tipset)
-      : ipld{std::make_shared<IpldBuffered>(env0.ipld)},
+  Env::Env(const EnvironmentContext &env_context,
+           TsBranchPtr ts_branch,
+           TipsetCPtr tipset)
+      : ipld{std::make_shared<IpldBuffered>(env_context.ipld)},
         state_tree{std::make_shared<StateTreeImpl>(
             this->ipld, tipset->getParentStateRoot())},
-        env0{env0},
+        env_context{env_context},
         epoch{tipset->height()},
         ts_branch{std::move(ts_branch)},
         tipset{std::move(tipset)} {
@@ -382,7 +384,7 @@ namespace fc::vm::runtime {
       _message.from = caller_id;
       auto runtime = std::make_shared<RuntimeImpl>(
           shared_from_this(), _message, caller_id);
-      auto result = env->env0.invoker->invoke(to_actor, runtime);
+      auto result = env->env_context.invoker->invoke(to_actor, runtime);
       catchAbort(result);
       return result;
     }

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -55,7 +55,7 @@ namespace fc::vm::runtime {
       DomainSeparationTag tag,
       ChainEpoch epoch,
       gsl::span<const uint8_t> seed) const {
-    return execution_->env->env0.randomness->getRandomnessFromTickets(
+    return execution_->env->env_context.randomness->getRandomnessFromTickets(
         execution_->env->ts_branch, tag, epoch, seed);
   }
 
@@ -63,7 +63,7 @@ namespace fc::vm::runtime {
       DomainSeparationTag tag,
       ChainEpoch epoch,
       gsl::span<const uint8_t> seed) const {
-    return execution_->env->env0.randomness->getRandomnessFromBeacon(
+    return execution_->env->env_context.randomness->getRandomnessFromBeacon(
         execution_->env->ts_branch, tag, epoch, seed);
   }
 
@@ -183,7 +183,7 @@ namespace fc::vm::runtime {
 
   outcome::result<TokenAmount> RuntimeImpl::getTotalFilCirculationSupply()
       const {
-    if (auto circulating{execution_->env->env0.circulating}) {
+    if (auto circulating{execution_->env->env_context.circulating}) {
       return circulating->circulating(execution_->state_tree,
                                       getCurrentEpoch());
     }
@@ -370,8 +370,9 @@ namespace fc::vm::runtime {
         auto &env{execution_->env};
         OUTCOME_TRY(it, find(env->ts_branch, getCurrentEpoch()));
         OUTCOME_TRYA(it, getLookbackTipSetForRound(it, block.height));
-        OUTCOME_TRY(cached,
-                    env->env0.interpreter_cache->get(it.second->second.key));
+        OUTCOME_TRY(
+            cached,
+            env->env_context.interpreter_cache->get(it.second->second.key));
         const StateTreeImpl state_tree{env->ipld, cached.state_root};
         OUTCOME_TRY(actor, state_tree.get(block.miner));
         Address worker;

--- a/core/vm/runtime/impl/runtime_impl.cpp
+++ b/core/vm/runtime/impl/runtime_impl.cpp
@@ -8,9 +8,18 @@
 #include "codec/cbor/cbor.hpp"
 #include "crypto/bls/impl/bls_provider_impl.hpp"
 #include "crypto/secp256k1/impl/secp256k1_provider_impl.hpp"
+#include "primitives/tipset/chain.hpp"
 #include "proofs/proofs.hpp"
 #include "storage/keystore/impl/in_memory/in_memory_keystore.hpp"
 #include "vm/actor/builtin/v0/account/account_actor.hpp"
+#include "vm/actor/builtin/v0/codes.hpp"
+#include "vm/actor/builtin/v0/miner/miner_actor_state.hpp"
+#include "vm/actor/builtin/v0/miner/policy.hpp"
+#include "vm/actor/builtin/v2/codes.hpp"
+#include "vm/actor/builtin/v2/miner/miner_actor_state.hpp"
+#include "vm/actor/builtin/v3/codes.hpp"
+#include "vm/actor/builtin/v3/miner/miner_actor_state.hpp"
+#include "vm/interpreter/interpreter.hpp"
 #include "vm/runtime/env.hpp"
 #include "vm/runtime/runtime_error.hpp"
 #include "vm/toolchain/toolchain.hpp"
@@ -48,7 +57,7 @@ namespace fc::vm::runtime {
       DomainSeparationTag tag,
       ChainEpoch epoch,
       gsl::span<const uint8_t> seed) const {
-    return execution_->env->randomness->getRandomnessFromTickets(
+    return execution_->env->env0.randomness->getRandomnessFromTickets(
         execution_->env->ts_branch, tag, epoch, seed);
   }
 
@@ -56,7 +65,7 @@ namespace fc::vm::runtime {
       DomainSeparationTag tag,
       ChainEpoch epoch,
       gsl::span<const uint8_t> seed) const {
-    return execution_->env->randomness->getRandomnessFromBeacon(
+    return execution_->env->env0.randomness->getRandomnessFromBeacon(
         execution_->env->ts_branch, tag, epoch, seed);
   }
 
@@ -176,7 +185,7 @@ namespace fc::vm::runtime {
 
   outcome::result<TokenAmount> RuntimeImpl::getTotalFilCirculationSupply()
       const {
-    if (auto circulating{execution_->env->circulating}) {
+    if (auto circulating{execution_->env->env0.circulating}) {
       return circulating->circulating(execution_->state_tree,
                                       getCurrentEpoch());
     }
@@ -285,10 +294,140 @@ namespace fc::vm::runtime {
     return proofs::Proofs::generateUnsealedCID(type, pieces, true);
   }
 
-  outcome::result<ConsensusFault> RuntimeImpl::verifyConsensusFault(
-      const Buffer &block1, const Buffer &block2, const Buffer &extra) {
-    // TODO(a.chernyshov): implement
-    return RuntimeError::kUnknown;
+  // TODO: reuse in block validation
+  outcome::result<bool> checkBlockSignature(const BlockHeader &block,
+                                            const Address &worker) {
+    if (!block.block_sig) {
+      return false;
+    }
+    auto block2{block};
+    block2.block_sig.reset();
+    OUTCOME_TRY(data, codec::cbor::encode(block2));
+    return storage::keystore::InMemoryKeyStore{
+        std::make_shared<crypto::bls::BlsProviderImpl>(),
+        std::make_shared<crypto::secp256k1::Secp256k1ProviderImpl>()}
+        .verify(worker, data, *block.block_sig);
+  }
+
+  // TODO: reuse
+  template <typename T>
+  inline bool has(const std::vector<T> &xs, const T &x) {
+    return std::find(xs.begin(), xs.end(), x) != xs.end();
+  }
+
+  // TODO: reuse in slash filter
+  inline bool isNearOrange(ChainEpoch epoch) {
+    using actor::builtin::v0::miner::kChainFinalityish;
+    using version::kUpgradeOrangeHeight;
+    return epoch > kUpgradeOrangeHeight - kChainFinalityish
+           && epoch < kUpgradeOrangeHeight + kChainFinalityish;
+  }
+
+  outcome::result<boost::optional<ConsensusFault>>
+  RuntimeImpl::verifyConsensusFault(const Buffer &block1,
+                                    const Buffer &block2,
+                                    const Buffer &extra) {
+    using common::getCidOf;
+    OUTCOME_TRY(chargeGas(execution_->env->pricelist.onVerifyConsensusFault()));
+    if (block1 == block2) {
+      return boost::none;
+    }
+    auto _blockA{codec::cbor::decode<BlockHeader>(block1)};
+    if (!_blockA) {
+      return boost::none;
+    }
+    auto &blockA{_blockA.value()};
+    auto _blockB{codec::cbor::decode<BlockHeader>(block2)};
+    if (!_blockB) {
+      return boost::none;
+    }
+    auto &blockB{_blockB.value()};
+    ConsensusFault fault;
+    fault.target = blockA.miner;
+    fault.epoch = blockB.height;
+    boost::optional<ConsensusFaultType> type;
+    if (isNearOrange(blockA.height) || isNearOrange(blockB.height)
+        || blockA.miner != blockB.miner || blockA.height > blockB.height) {
+      return boost::none;
+    }
+    if (blockA.height == blockB.height) {
+      type = ConsensusFaultType::DoubleForkMining;
+    } else if (blockA.parents == blockB.parents) {
+      type = ConsensusFaultType::TimeOffsetMining;
+    }
+    if (!extra.empty()) {
+      if (auto _blockC{codec::cbor::decode<BlockHeader>(extra)}) {
+        auto &blockC{_blockC.value()};
+        if (blockA.parents == blockC.parents && blockA.height == blockC.height
+            && has(blockB.parents, getCidOf(extra).value())
+            && !has(blockB.parents, getCidOf(block1).value())) {
+          type = ConsensusFaultType::ParentGrinding;
+        }
+      } else {
+        return boost::none;
+      }
+    }
+    if (type) {
+      auto verify2{[&](const BlockHeader &block) -> outcome::result<bool> {
+        if (getNetworkVersion() >= NetworkVersion::kVersion7
+            && static_cast<ChainEpoch>(block.height)
+                   < getCurrentEpoch()
+                         - vm::actor::builtin::v0::miner::kChainFinalityish) {
+          return false;
+        }
+        auto &env{execution_->env};
+        OUTCOME_TRY(it, find(env->ts_branch, getCurrentEpoch()));
+        OUTCOME_TRYA(it, getLookbackTipSetForRound(it, block.height));
+        OUTCOME_TRY(cached,
+                    env->env0.interpreter_cache->get(it.second->second.key));
+        spdlog::info("VCF L {} {}", it.second->first, cached.state_root);
+        StateTreeImpl state_tree{env->ipld, cached.state_root};
+        OUTCOME_TRY(actor, state_tree.get(block.miner));
+        Address worker;
+        auto &ipld{execution_->charging_ipld};
+        if (actor.code == actor::builtin::v0::kStorageMinerCodeId) {
+          OUTCOME_TRY(
+              state,
+              ipld->getCbor<actor::builtin::v0::miner::State>(actor.head));
+          OUTCOME_TRY(info, state.info.get());
+          worker = info.worker;
+        } else if (actor.code == actor::builtin::v2::kStorageMinerCodeId) {
+          OUTCOME_TRY(
+              state,
+              ipld->getCbor<actor::builtin::v2::miner::State>(actor.head));
+          OUTCOME_TRY(info, state.info.get());
+          worker = info.worker;
+        } else if (actor.code == actor::builtin::v3::kStorageMinerCodeId) {
+          OUTCOME_TRY(
+              state,
+              ipld->getCbor<actor::builtin::v3::miner::State>(actor.head));
+          OUTCOME_TRY(info, state.info.get());
+          worker = info.worker;
+        }
+        OUTCOME_TRY(key, resolveKey(*execution_->state_tree, ipld, worker));
+        return checkBlockSignature(block, key);
+      }};
+      auto verify{[&](const BlockHeader &block) -> outcome::result<bool> {
+        if (auto _ok{verify2(block)}) {
+          return _ok;
+        } else if (isAbortExitCode(_ok.error())) {
+          return _ok;
+        } else {
+          return false;
+        }
+      }};
+      OUTCOME_TRY(okA, verify(blockA));
+      if (!okA) {
+        return boost::none;
+      }
+      OUTCOME_TRY(okB, verify(blockA));
+      if (!okB) {
+        return boost::none;
+      }
+      fault.type = *type;
+      return fault;
+    }
+    return boost::none;
   }
 
   outcome::result<Blake2b256Hash> RuntimeImpl::hashBlake2b(

--- a/core/vm/runtime/impl/runtime_impl.hpp
+++ b/core/vm/runtime/impl/runtime_impl.hpp
@@ -114,7 +114,7 @@ namespace fc::vm::runtime {
         RegisteredSealProof type,
         const std::vector<PieceInfo> &pieces) override;
 
-    outcome::result<ConsensusFault> verifyConsensusFault(
+    outcome::result<boost::optional<ConsensusFault>> verifyConsensusFault(
         const Buffer &block1,
         const Buffer &block2,
         const Buffer &extra) override;

--- a/core/vm/runtime/impl/tipset_randomness.cpp
+++ b/core/vm/runtime/impl/tipset_randomness.cpp
@@ -27,9 +27,8 @@ namespace fc::vm::runtime {
       DomainSeparationTag tag,
       ChainEpoch epoch,
       gsl::span<const uint8_t> seed) const {
-    OUTCOME_TRY(
-        beacon,
-        latestBeacon(ts_load, ts_branch, std::max<ChainEpoch>(0, epoch)));
+    OUTCOME_TRY(it, find(ts_branch, std::max<ChainEpoch>(0, epoch)));
+    OUTCOME_TRY(beacon, latestBeacon(ts_load, it));
     return crypto::randomness::drawRandomness(beacon.data, tag, epoch, seed);
   }
 

--- a/core/vm/runtime/runtime.hpp
+++ b/core/vm/runtime/runtime.hpp
@@ -240,8 +240,10 @@ namespace fc::vm::runtime {
         RegisteredSealProof type, const std::vector<PieceInfo> &pieces) = 0;
 
     /// Verify consensus fault
-    virtual outcome::result<ConsensusFault> verifyConsensusFault(
-        const Buffer &block1, const Buffer &block2, const Buffer &extra) = 0;
+    virtual outcome::result<boost::optional<ConsensusFault>>
+    verifyConsensusFault(const Buffer &block1,
+                         const Buffer &block2,
+                         const Buffer &extra) = 0;
 
     /// Return a hash of data
     virtual outcome::result<Blake2b256Hash> hashBlake2b(

--- a/test/core/blockchain/validation/block_validator_test.cpp
+++ b/test/core/blockchain/validation/block_validator_test.cpp
@@ -58,7 +58,6 @@ class BlockValidatorTest : public testing::Test {
     BOOST_ASSERT(!result.has_error());
     auto bls_provider = std::make_shared<BlsProvider>();
     auto secp_provider = std::make_shared<Secp256k1Provider>();
-    auto vm_interpreter = std::make_shared<Interpreter>();
     return std::make_shared<BlockValidator>(datastore,
                                             utc_clock,
                                             epoch_clock,
@@ -66,7 +65,7 @@ class BlockValidatorTest : public testing::Test {
                                             power_table,
                                             bls_provider,
                                             secp_provider,
-                                            vm_interpreter);
+                                            nullptr);
   }
 
   BlockHeader getCorrectBlockHeader() const {

--- a/test/core/test_vectors/test.cpp
+++ b/test/core/test_vectors/test.cpp
@@ -283,8 +283,9 @@ void testTipsets(const MessageVector &mv, const IpldPtr &ipld) {
     std::shared_ptr<RuntimeRandomness> randomness =
         std::make_shared<ReplayingRandomness>(mv.randomness);
     auto ts_load{std::make_shared<fc::primitives::tipset::TsLoadIpld>(ipld)};
-    fc::vm::runtime::Env0 env0{ipld, invoker, randomness, ts_load};
-    fc::vm::interpreter::InterpreterImpl vmi{env0, nullptr};
+    fc::vm::runtime::EnvironmentContext env_context{
+        ipld, invoker, randomness, ts_load};
+    fc::vm::interpreter::InterpreterImpl vmi{env_context, nullptr};
     CID state{mv.state_before};
     BlockHeader parent;
     parent.ticket.emplace();
@@ -360,8 +361,8 @@ void testMessages(const MessageVector &mv, IpldPtr ipld) {
     std::shared_ptr<Invoker> invoker = std::make_shared<InvokerImpl>();
     std::shared_ptr<RuntimeRandomness> randomness =
         std::make_shared<ReplayingRandomness>(mv.randomness);
-    fc::vm::runtime::Env0 env0{ipld, invoker, randomness};
-    auto env{std::make_shared<fc::vm::runtime::Env>(env0, nullptr, ts)};
+    fc::vm::runtime::EnvironmentContext env_context{ipld, invoker, randomness};
+    auto env{std::make_shared<fc::vm::runtime::Env>(env_context, nullptr, ts)};
     auto i{0};
     for (const auto &[epoch_offset, message] : mv.messages) {
       const auto &receipt{mv.receipts[i]};

--- a/test/testutil/mocks/vm/interpreter/interpreter_mock.hpp
+++ b/test/testutil/mocks/vm/interpreter/interpreter_mock.hpp
@@ -13,9 +13,8 @@
 namespace fc::vm::interpreter {
   class InterpreterMock : public Interpreter {
    public:
-    MOCK_CONST_METHOD3(interpret,
+    MOCK_CONST_METHOD2(interpret,
                        outcome::result<Result>(TsBranchPtr,
-                                               const IpldPtr &store,
                                                const TipsetCPtr &tipset));
   };
 }  // namespace fc::vm::interpreter

--- a/test/testutil/mocks/vm/runtime/runtime_mock.hpp
+++ b/test/testutil/mocks/vm/runtime/runtime_mock.hpp
@@ -108,10 +108,11 @@ namespace fc::vm::runtime {
                  outcome::result<CID>(RegisteredSealProof,
                                       const std::vector<PieceInfo> &));
 
-    MOCK_METHOD3(verifyConsensusFault,
-                 outcome::result<ConsensusFault>(const Buffer &block1,
-                                                 const Buffer &block2,
-                                                 const Buffer &extra));
+    MOCK_METHOD3(
+        verifyConsensusFault,
+        outcome::result<boost::optional<ConsensusFault>>(const Buffer &block1,
+                                                         const Buffer &block2,
+                                                         const Buffer &extra));
 
     /// Expect call to send with params returning result
     template <typename M>


### PR DESCRIPTION
- Separate `InterpreterCache` from `Interpreter`
- Move shared vm objects to `Env0` (suggest your own type and variable name)
- `catchAbort`
- `verifyConsensusFault`