### PR TITLE
move getCbor

### DIFF
--- a/core/adt/array.hpp
+++ b/core/adt/array.hpp
@@ -68,7 +68,7 @@ namespace fc::adt {
 
     outcome::result<void> visit(const Visitor &visitor) const {
       return amt.visit([&](auto key, auto &value) -> outcome::result<void> {
-        OUTCOME_TRY(value2, amt.ipld->decode<Value>(value));
+        OUTCOME_TRY(value2, cbor_blake::cbDecodeT<Value>(amt.ipld, value));
         return visitor(key, value2);
       });
     }
@@ -109,18 +109,18 @@ namespace fc::adt {
   }
 }  // namespace fc::adt
 
-namespace fc {
+namespace fc::cbor_blake {
   template <typename V>
-  struct Ipld::Load<adt::Array<V>> {
-    static void call(Ipld &ipld, adt::Array<V> &array) {
-      array.amt.ipld = ipld.shared();
+  struct CbLoadT<adt::Array<V>> {
+    static void call(CbIpldPtrIn ipld, adt::Array<V> &array) {
+      array.amt.ipld = ipld;
     }
   };
 
   template <typename V>
-  struct Ipld::Flush<adt::Array<V>> {
+  struct CbFlushT<adt::Array<V>> {
     static auto call(adt::Array<V> &array) {
       return array.amt.flush();
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/adt/balance_table.hpp
+++ b/core/adt/balance_table.hpp
@@ -29,15 +29,15 @@ namespace fc::adt {
   };
 }  // namespace fc::adt
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<adt::BalanceTable> {
+  struct CbVisitT<adt::BalanceTable> {
     template <typename Visitor>
     static void call(adt::Map<adt::TokenAmount, adt::AddressKeyer> &map,
                      const Visitor &visit) {
       visit(map);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake
 
 OUTCOME_HPP_DECLARE_ERROR(fc::adt, BalanceTableError);

--- a/core/adt/cid_t.hpp
+++ b/core/adt/cid_t.hpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "cbor_blake/ipld_cbor.hpp"
+
+namespace fc::adt {
+  template <typename T>
+  struct CbCidT {
+    // TODO(turuslan): refactor CID to CbCid
+    CID cid;
+    // TODO(turuslan): refactor Ipld to CbIpld
+    IpldPtr ipld{};
+
+    CbCidT() = default;
+    CbCidT(CID cid) : cid{std::move(cid)} {}
+
+    auto get() const {
+      return getCbor<T>(ipld, cid);
+    }
+    outcome::result<void> set(const T &value) {
+      OUTCOME_TRYA(cid, setCbor(ipld, value));
+      return outcome::success();
+    }
+
+    operator const CID &() const {
+      return cid;
+    }
+  };
+  template <typename T>
+  CBOR2_DECODE(CbCidT<T>) {
+    return s >> v.cid;
+  }
+  template <typename T>
+  CBOR2_ENCODE(CbCidT<T>) {
+    return s << v.cid;
+  }
+}  // namespace fc::adt
+
+namespace fc::cbor_blake {
+  template <typename T>
+  struct CbLoadT<adt::CbCidT<T>> {
+    static void call(CbIpldPtrIn ipld, adt::CbCidT<T> &cid) {
+      cid.ipld = ipld;
+    }
+  };
+}  // namespace fc::cbor_blake

--- a/core/adt/map.hpp
+++ b/core/adt/map.hpp
@@ -60,7 +60,7 @@ namespace fc::adt {
     outcome::result<void> visit(const Visitor &visitor) const {
       return hamt.visit([&](auto key, auto value) -> outcome::result<void> {
         OUTCOME_TRY(key2, Keyer::decode(key));
-        OUTCOME_TRY(value2, hamt.ipld->decode<Value>(value));
+        OUTCOME_TRY(value2, cbor_blake::cbDecodeT<Value>(hamt.ipld, value));
         return visitor(key2, value2);
       });
     }
@@ -120,18 +120,18 @@ namespace fc::adt {
   }
 }  // namespace fc::adt
 
-namespace fc {
+namespace fc::cbor_blake {
   template <typename V, typename Keyer, size_t bit_width, bool v3>
-  struct Ipld::Load<adt::Map<V, Keyer, bit_width, v3>> {
-    static void call(Ipld &ipld, adt::Map<V, Keyer, bit_width, v3> &map) {
-      map.hamt.ipld = ipld.shared();
+  struct CbLoadT<adt::Map<V, Keyer, bit_width, v3>> {
+    static void call(CbIpldPtrIn ipld, adt::Map<V, Keyer, bit_width, v3> &map) {
+      map.hamt.ipld = ipld;
     }
   };
 
   template <typename V, typename Keyer, size_t bit_width, bool v3>
-  struct Ipld::Flush<adt::Map<V, Keyer, bit_width, v3>> {
+  struct CbFlushT<adt::Map<V, Keyer, bit_width, v3>> {
     static auto call(adt::Map<V, Keyer, bit_width, v3> &map) {
       return map.hamt.flush();
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/adt/set.hpp
+++ b/core/adt/set.hpp
@@ -23,13 +23,13 @@ namespace fc::adt {
   struct Set : Map<SetValue, Keyer, bit_width, v3> {};
 }  // namespace fc::adt
 
-namespace fc {
+namespace fc::cbor_blake {
   template <typename Keyer, size_t bit_width, bool v3>
-  struct Ipld::Visit<adt::Set<Keyer, bit_width, v3>> {
+  struct CbVisitT<adt::Set<Keyer, bit_width, v3>> {
     template <typename Visitor>
     static void call(adt::Map<adt::SetValue, Keyer, bit_width, v3> &map,
                      const Visitor &visit) {
       visit(map);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/blockchain/production/block_producer.cpp
+++ b/core/blockchain/production/block_producer.cpp
@@ -25,7 +25,7 @@ namespace fc::blockchain::production {
     OUTCOME_TRY(vm_result, interpreter_cache.get(parent_tipset->key));
     BlockWithMessages b;
     MsgMeta msg_meta;
-    ipld->load(msg_meta);
+    cbor_blake::cbLoadT(ipld, msg_meta);
     std::vector<crypto::bls::Signature> bls_signatures;
     for (auto &message : t.messages) {
       OUTCOME_TRY(visit_in_place(
@@ -33,13 +33,13 @@ namespace fc::blockchain::production {
           [&](const BlsSignature &signature) -> outcome::result<void> {
             b.bls_messages.emplace_back(message.message);
             bls_signatures.push_back(signature);
-            OUTCOME_TRY(message_cid, ipld->setCbor(message.message));
+            OUTCOME_TRY(message_cid, setCbor(ipld, message.message));
             OUTCOME_TRY(msg_meta.bls_messages.append(message_cid));
             return outcome::success();
           },
           [&](const Secp256k1Signature &signature) -> outcome::result<void> {
             b.secp_messages.emplace_back(message);
-            OUTCOME_TRY(message_cid, ipld->setCbor(message));
+            OUTCOME_TRY(message_cid, setCbor(ipld, message));
             OUTCOME_TRY(msg_meta.secp_messages.append(message_cid));
             return outcome::success();
           }));
@@ -54,7 +54,7 @@ namespace fc::blockchain::production {
     b.header.height = t.height;
     b.header.parent_state_root = std::move(vm_result.state_root);
     b.header.parent_message_receipts = std::move(vm_result.message_receipts);
-    OUTCOME_TRYA(b.header.messages, ipld->setCbor(msg_meta));
+    OUTCOME_TRYA(b.header.messages, setCbor(ipld, msg_meta));
     OUTCOME_TRYA(
         b.header.bls_aggregate,
         crypto::bls::BlsProviderImpl{}.aggregateSignatures(bls_signatures));

--- a/core/cbor_blake/ipld_any.hpp
+++ b/core/cbor_blake/ipld_any.hpp
@@ -11,7 +11,7 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc {
-  struct CbAsAnyIpld : Ipld, std::enable_shared_from_this<CbAsAnyIpld> {
+  struct CbAsAnyIpld : Ipld {
     CbIpldPtr ipld;
 
     CbAsAnyIpld(CbIpldPtr ipld) : ipld{std::move(ipld)} {}
@@ -36,9 +36,6 @@ namespace fc {
         }
       }
       return storage::ipfs::IpfsDatastoreError::kNotFound;
-    }
-    IpldPtr shared() override {
-      return shared_from_this();
     }
   };
 

--- a/core/cbor_blake/ipld_cbor.hpp
+++ b/core/cbor_blake/ipld_cbor.hpp
@@ -1,0 +1,98 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// TODO(turuslan): refactor Ipld to CbIpld
+#include "storage/ipfs/datastore.hpp"
+
+namespace fc::primitives::block {
+  struct BlockHeader;
+}  // namespace fc::primitives::block
+
+namespace fc::cbor_blake {
+  // TODO(turuslan): refactor Ipld to CbIpld
+  using CbIpldPtr = IpldPtr;
+  using CbIpldPtrIn = const CbIpldPtr &;
+
+  template <typename T>
+  void cbLoadT(CbIpldPtrIn ipld, T &value);
+  template <typename T>
+  outcome::result<void> cbFlushT(T &value);
+
+  template <typename T>
+  outcome::result<T> cbDecodeT(CbIpldPtrIn ipld, BytesIn cbor) {
+    OUTCOME_TRY(value, codec::cbor::decode<T>(cbor));
+    cbLoadT(ipld, value);
+    return std::move(value);
+  }
+
+  template <typename T>
+  outcome::result<Buffer> cbEncodeT(const T &value) {
+    OUTCOME_TRY(cbFlushT(value));
+    return codec::cbor::encode(value);
+  }
+
+  // TODO(turuslan): refactor CID to CbCid
+  template <typename T>
+  outcome::result<T> getCbor(CbIpldPtrIn ipld, const CID &key) {
+    OUTCOME_TRY(cbor, ipld->get(key));
+    return cbDecodeT<T>(ipld, cbor);
+  }
+
+  // TODO(turuslan): refactor CID to CbCid
+  template <typename T>
+  outcome::result<CID> setCbor(CbIpldPtrIn ipld, const T &value) {
+    static_assert(!std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>,
+                                  primitives::block::BlockHeader>);
+    OUTCOME_TRY(cbor, cbEncodeT(value));
+    CID key{CbCid::hash(cbor)};
+    OUTCOME_TRY(ipld->set(key, std::move(cbor)));
+    return key;
+  }
+
+  template <typename T>
+  struct CbVisitT {
+    template <typename Visitor>
+    static void call(T &, const Visitor &) {}
+  };
+
+  template <typename T>
+  struct CbLoadT {
+    static void call(CbIpldPtrIn ipld, T &value) {
+      CbVisitT<T>::call(value, [&](auto &x) { cbLoadT(ipld, x); });
+    }
+  };
+
+  template <typename T>
+  struct CbFlushT {
+    static outcome::result<void> call(T &value) {
+      outcome::result<void> result{outcome::success()};
+      CbVisitT<T>::call(value, [&](auto &x) {
+        if (result) {
+          result = cbFlushT(x);
+        }
+      });
+      return result;
+    }
+  };
+
+  template <typename T>
+  void cbLoadT(CbIpldPtrIn ipld, T &value) {
+    CbLoadT<T>::call(ipld, value);
+  }
+
+  template <typename T>
+  outcome::result<void> cbFlushT(T &value) {
+    using Z = std::remove_const_t<T>;
+    OUTCOME_TRY(CbFlushT<Z>::call(const_cast<Z &>(value)));
+    return outcome::success();
+  }
+}  // namespace fc::cbor_blake
+
+namespace fc {
+  using cbor_blake::getCbor;
+  using cbor_blake::setCbor;
+}  // namespace fc

--- a/core/codec/cbor/cbor_decode_stream.hpp
+++ b/core/codec/cbor/cbor_decode_stream.hpp
@@ -177,7 +177,9 @@ namespace fc::codec::cbor {
     }
     void readToken() {
       input = partial;
-      if (!partial.empty() && !read(token, partial)) {
+      if (partial.empty()) {
+        token = {};
+      } else if (!read(token, partial)) {
         outcome::raise(CborDecodeError::kInvalidCbor);
       }
     }

--- a/core/node/blocksync_server.cpp
+++ b/core/node/blocksync_server.cpp
@@ -63,7 +63,7 @@ namespace fc::sync::blocksync {
         auto index{visited.find(cid)};
         if (index == visited.end()) {
           index = visited.emplace(cid, messages.size()).first;
-          OUTCOME_TRY(message, ipld->getCbor<T>(cid));
+          OUTCOME_TRY(message, getCbor<T>(ipld, cid));
           messages.push_back(std::move(message));
         }
         indices.rbegin()->push_back(index->second);
@@ -100,7 +100,7 @@ namespace fc::sync::blocksync {
             for (auto &block : ts->blks) {
               OUTCOME_TRY(
                   meta,
-                  ipld->getCbor<primitives::block::MsgMeta>(block.messages));
+                  getCbor<primitives::block::MsgMeta>(ipld, block.messages));
               msgs.bls_msg_includes.emplace_back();
               OUTCOME_TRY(meta.bls_messages.visit(bls_visitor));
               msgs.secp_msg_includes.emplace_back();

--- a/core/node/sync_job.cpp
+++ b/core/node/sync_job.cpp
@@ -77,8 +77,8 @@ namespace fc::sync {
 
     message_event_ =
         events_->subscribeMessageFromPubSub([ipld{ipld_}](auto &e) {
-          std::ignore = e.msg.signature.isBls() ? ipld->setCbor(e.msg.message)
-                                                : ipld->setCbor(e.msg);
+          std::ignore = e.msg.signature.isBls() ? setCbor(ipld, e.msg.message)
+                                                : setCbor(ipld, e.msg);
         });
 
     block_event_ = events_->subscribeBlockFromPubSub([=](auto &e) {
@@ -87,7 +87,7 @@ namespace fc::sync {
         primitives::tipset::put(ipld, put_block_header_, e.block.header);
         std::shared_lock ts_lock{*ts_branches_mutex_};
         primitives::block::MsgMeta meta;
-        ipld->load(meta);
+        cbor_blake::cbLoadT(ipld, meta);
         for (auto &cid : e.block.bls_messages) {
           OUTCOME_TRY(ipld->get(cid));
           OUTCOME_TRY(meta.bls_messages.append(cid));
@@ -96,7 +96,7 @@ namespace fc::sync {
           OUTCOME_TRY(ipld->get(cid));
           OUTCOME_TRY(meta.secp_messages.append(cid));
         }
-        OUTCOME_TRY(ipld->setCbor(meta));
+        OUTCOME_TRY(setCbor(ipld, meta));
         return outcome::success();
       }();
     });

--- a/core/payment_channel_manager/impl/payment_channel_manager_impl.hpp
+++ b/core/payment_channel_manager/impl/payment_channel_manager_impl.hpp
@@ -16,9 +16,8 @@
 namespace fc::payment_channel_manager {
   using api::FullNodeApi;
   using common::Buffer;
-  using vm::actor::builtin::types::payment_channel::SignedVoucher;
-  using Ipld = fc::storage::ipfs::IpfsDatastore;
   using vm::actor::builtin::states::PaymentChannelActorStatePtr;
+  using vm::actor::builtin::types::payment_channel::SignedVoucher;
 
   struct ChannelInfo {
     Address channel_actor;

--- a/core/primitives/block/block.hpp
+++ b/core/primitives/block/block.hpp
@@ -131,13 +131,13 @@ namespace fc::primitives::block {
              parent_base_fee)
 }  // namespace fc::primitives::block
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<primitives::block::MsgMeta> {
+  struct CbVisitT<primitives::block::MsgMeta> {
     template <typename Visitor>
     static void call(primitives::block::MsgMeta &meta, const Visitor &visit) {
       visit(meta.bls_messages);
       visit(meta.secp_messages);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/primitives/tipset/load.cpp
+++ b/core/primitives/tipset/load.cpp
@@ -17,7 +17,7 @@ namespace fc::primitives::tipset {
     std::vector<BlockHeader> blocks;
     blocks.reserve(key.cids().size());
     for (auto &cid : key.cids()) {
-      OUTCOME_TRY(block, ipld->getCbor<BlockHeader>(CID{cid}));
+      OUTCOME_TRY(block, getCbor<BlockHeader>(ipld, CID{cid}));
       blocks.emplace_back(std::move(block));
     }
     return TsLoad::load(std::move(blocks));

--- a/core/primitives/tipset/tipset.cpp
+++ b/core/primitives/tipset/tipset.cpp
@@ -72,9 +72,9 @@ namespace fc::primitives::tipset {
         auto &msg{smsg.message};
         if (load) {
           if (bls) {
-            OUTCOME_TRYA(msg, ipld->getCbor<UnsignedMessage>(cid));
+            OUTCOME_TRYA(msg, getCbor<UnsignedMessage>(ipld, cid));
           } else {
-            OUTCOME_TRYA(smsg, ipld->getCbor<SignedMessage>(cid));
+            OUTCOME_TRYA(smsg, getCbor<SignedMessage>(ipld, cid));
           }
         }
         if (nonce) {
@@ -106,7 +106,7 @@ namespace fc::primitives::tipset {
       }
       return outcome::success();
     };
-    OUTCOME_TRY(meta, ipld->getCbor<block::MsgMeta>(block.messages));
+    OUTCOME_TRY(meta, getCbor<block::MsgMeta>(ipld, block.messages));
     OUTCOME_TRY(meta.bls_messages.visit(
         [&](auto, auto &cid) { return onMessage(true, cid); }));
     OUTCOME_TRY(meta.secp_messages.visit(

--- a/core/storage/amt/amt.hpp
+++ b/core/storage/amt/amt.hpp
@@ -86,7 +86,7 @@ namespace fc::storage::amt {
     /// Store CBOR encoded value by key
     template <typename T>
     outcome::result<void> setCbor(uint64_t key, const T &value) {
-      OUTCOME_TRY(bytes, Ipld::encode(value));
+      OUTCOME_TRY(bytes, cbor_blake::cbEncodeT(value));
       return set(key, bytes);
     }
 
@@ -94,7 +94,7 @@ namespace fc::storage::amt {
     template <typename T>
     outcome::result<T> getCbor(uint64_t key) const {
       OUTCOME_TRY(bytes, get(key));
-      return ipld->decode<T>(bytes);
+      return cbor_blake::cbDecodeT<T>(ipld, bytes);
     }
 
     IpldPtr ipld;

--- a/core/storage/amt/amt_walk.cpp
+++ b/core/storage/amt/amt_walk.cpp
@@ -208,7 +208,7 @@ namespace fc::storage::amt {
     if (which<Root>(root_)) {
       auto &root = boost::get<Root>(root_);
       OUTCOME_TRY(flush(root.node));
-      OUTCOME_TRY(root_cid, ipld->setCbor(root));
+      OUTCOME_TRY(root_cid, fc::setCbor(ipld, root));
       root_ = root_cid;
     }
     return cid();
@@ -282,7 +282,7 @@ namespace fc::storage::amt {
         if (which<Node::Ptr>(pair.second)) {
           auto &child = *boost::get<Node::Ptr>(pair.second);
           OUTCOME_TRY(flush(child));
-          OUTCOME_TRY(cid, ipld->setCbor(child));
+          OUTCOME_TRY(cid, fc::setCbor(ipld, child));
           pair.second = cid;
         }
       }
@@ -313,7 +313,7 @@ namespace fc::storage::amt {
 
   outcome::result<void> Amt::loadRoot() const {
     if (which<CID>(root_)) {
-      OUTCOME_TRY(root, ipld->getCbor<Root>(boost::get<CID>(root_)));
+      OUTCOME_TRY(root, fc::getCbor<Root>(ipld, boost::get<CID>(root_)));
       root_ = root;
       if (root.bits != bits_) {
         return AmtError::kRootBitsWrong;
@@ -342,7 +342,7 @@ namespace fc::storage::amt {
     }
     auto &link = it->second;
     if (which<CID>(link)) {
-      OUTCOME_TRY(node, ipld->getCbor<Node>(boost::get<CID>(link)));
+      OUTCOME_TRY(node, fc::getCbor<Node>(ipld, boost::get<CID>(link)));
       if (node.bits_bytes != bitsBytes()) {
         return AmtError::kRootBitsWrong;
       }

--- a/core/storage/car/car.hpp
+++ b/core/storage/car/car.hpp
@@ -11,7 +11,6 @@
 #include "storage/ipld/selector.hpp"
 
 namespace fc::storage::car {
-  using Ipld = ipfs::IpfsDatastore;
   using Input = gsl::span<const uint8_t>;
   using common::Buffer;
   using ipld::Selector;

--- a/core/storage/hamt/hamt.hpp
+++ b/core/storage/hamt/hamt.hpp
@@ -118,7 +118,7 @@ namespace fc::storage::hamt {
     /// Store CBOR encoded value by key
     template <typename T>
     outcome::result<void> setCbor(BytesIn key, const T &value) {
-      OUTCOME_TRY(bytes, Ipld::encode(value));
+      OUTCOME_TRY(bytes, cbor_blake::cbEncodeT(value));
       return set(key, bytes);
     }
 
@@ -126,7 +126,7 @@ namespace fc::storage::hamt {
     template <typename T>
     outcome::result<T> getCbor(BytesIn key) const {
       OUTCOME_TRY(bytes, get(key));
-      return ipld->decode<T>(bytes);
+      return cbor_blake::cbDecodeT<T>(ipld, bytes);
     }
 
     /// Get CBOR decoded value by key
@@ -139,7 +139,7 @@ namespace fc::storage::hamt {
         }
         return boost::none;
       }
-      OUTCOME_TRY(value, ipld->decode<T>(maybe.value()));
+      OUTCOME_TRY(value, cbor_blake::cbDecodeT<T>(ipld, maybe.value()));
       return std::move(value);
     }
 

--- a/core/storage/hamt/hamt_walk.cpp
+++ b/core/storage/hamt/hamt_walk.cpp
@@ -305,7 +305,7 @@ namespace fc::storage::hamt {
       for (auto &item2 : node.items) {
         OUTCOME_TRY(flush(item2.second));
       }
-      OUTCOME_TRYA(item, ipld->setCbor(node));
+      OUTCOME_TRYA(item, fc::setCbor(ipld, node));
     }
     return outcome::success();
   }
@@ -316,7 +316,7 @@ namespace fc::storage::hamt {
 
   outcome::result<void> Hamt::loadItem(Node::Item &item) const {
     if (which<CID>(item)) {
-      OUTCOME_TRY(child, ipld->getCbor<Node>(boost::get<CID>(item)));
+      OUTCOME_TRY(child, fc::getCbor<Node>(ipld, boost::get<CID>(item)));
       if (!child.v3) {
         child.v3 = v3_;
       } else if (*child.v3 != v3_) {

--- a/core/storage/ipfs/api_ipfs_datastore/api_ipfs_datastore.cpp
+++ b/core/storage/ipfs/api_ipfs_datastore/api_ipfs_datastore.cpp
@@ -23,9 +23,4 @@ namespace fc::storage::ipfs {
       const CID &key) const {
     return api_->ChainReadObj(key);
   }
-
-  std::shared_ptr<IpfsDatastore> ApiIpfsDatastore::shared() {
-    return shared_from_this();
-  }
-
 }  // namespace fc::storage::ipfs

--- a/core/storage/ipfs/api_ipfs_datastore/api_ipfs_datastore.hpp
+++ b/core/storage/ipfs/api_ipfs_datastore/api_ipfs_datastore.hpp
@@ -14,9 +14,7 @@ namespace fc::storage::ipfs {
   /**
    * Read-only implementation of IPFS over node API
    */
-  class ApiIpfsDatastore
-      : public IpfsDatastore,
-        public std::enable_shared_from_this<ApiIpfsDatastore> {
+  class ApiIpfsDatastore : public Ipld {
    public:
     /**
      * Construct ApiIpfsDatastore
@@ -35,8 +33,6 @@ namespace fc::storage::ipfs {
     outcome::result<void> set(const CID &key, Value value) override;
 
     outcome::result<Value> get(const CID &key) const override;
-
-    std::shared_ptr<IpfsDatastore> shared() override;
 
    private:
     std::shared_ptr<FullNodeApi> api_;

--- a/core/storage/ipfs/datastore.hpp
+++ b/core/storage/ipfs/datastore.hpp
@@ -10,10 +10,6 @@
 #include "codec/cbor/cbor_codec.hpp"
 #include "storage/ipfs/ipfs_datastore_error.hpp"
 
-namespace fc::primitives::block {
-  struct BlockHeader;
-}  // namespace fc::primitives::block
-
 namespace fc::storage::ipfs {
 
   class IpfsDatastore {
@@ -43,108 +39,13 @@ namespace fc::storage::ipfs {
      * @return value associated with key or error
      */
     virtual outcome::result<Value> get(const CID &key) const = 0;
-
-    virtual std::shared_ptr<IpfsDatastore> shared() = 0;
-
-    /**
-     * @brief CBOR-serialize value and store
-     * @param value - data to serialize and store
-     * @return cid of CBOR-serialized data
-     */
-    template <typename T>
-    outcome::result<CID> setCbor(const T &value) {
-      static_assert(
-          !std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>,
-                          primitives::block::BlockHeader>);
-      OUTCOME_TRY(bytes, encode(value));
-      OUTCOME_TRY(key, common::getCidOf(bytes));
-      OUTCOME_TRY(set(key, std::move(bytes)));
-      return std::move(key);
-    }
-
-    /// Get CBOR decoded value by CID
-    template <typename T>
-    outcome::result<T> getCbor(const CID &key) const {
-      OUTCOME_TRY(bytes, get(key));
-      return decode<T>(bytes);
-    }
-
-    template <typename T>
-    static outcome::result<Value> encode(const T &value) {
-      OUTCOME_TRY(flush(value));
-      return codec::cbor::encode(value);
-    }
-
-    template <typename T>
-    outcome::result<T> decode(gsl::span<const uint8_t> input) const {
-      OUTCOME_TRY(value, codec::cbor::decode<T>(input));
-      load(value);
-      return std::move(value);
-    }
-
-    template <typename T>
-    void load(T &value) const {
-      Load<T>::call(const_cast<IpfsDatastore &>(*this), value);
-    }
-
-    template <typename T>
-    static auto flush(T &value) {
-      using Z = std::remove_const_t<T>;
-      return Flush<Z>::call(const_cast<Z &>(value));
-    }
-
-    template <typename T>
-    struct Visit {
-      template <typename Visitor>
-      static void call(T &, const Visitor &) {}
-    };
-
-    template <typename T>
-    struct Load {
-      static void call(IpfsDatastore &ipld, T &value) {
-        Visit<T>::call(value, [&](auto &x) { ipld.load(x); });
-      }
-    };
-
-    template <typename T>
-    struct Flush {
-      static outcome::result<void> call(T &value) {
-        try {
-          Visit<T>::call(
-              value, [](auto &x) { OUTCOME_EXCEPT(IpfsDatastore::flush(x)); });
-        } catch (std::system_error &e) {
-          return outcome::failure(e.code());
-        }
-        return outcome::success();
-      }
-    };
   };
 }  // namespace fc::storage::ipfs
 
 namespace fc {
   using Ipld = storage::ipfs::IpfsDatastore;
   using IpldPtr = std::shared_ptr<Ipld>;
-
-  template <typename T>
-  struct CIDT : public CID {
-    CIDT() : CID() {}
-    CIDT(CID &&cid) noexcept : CID(cid) {}
-    explicit CIDT(const CID &cid) : CID(cid) {}
-
-    auto get() const {
-      return ipld->getCbor<T>(*this);
-    }
-    outcome::result<void> set(const T &value) {
-      OUTCOME_TRYA(*this, ipld->setCbor(value));
-      return outcome::success();
-    }
-    IpldPtr ipld;
-  };
-
-  template <typename T>
-  struct Ipld::Load<CIDT<T>> {
-    static void call(Ipld &ipld, CIDT<T> &cid) {
-      cid.ipld = ipld.shared();
-    }
-  };
 }  // namespace fc
+
+// TODO(turuslan): refactor includes
+#include "cbor_blake/ipld_cbor.hpp"

--- a/core/storage/ipfs/impl/datastore_leveldb.hpp
+++ b/core/storage/ipfs/impl/datastore_leveldb.hpp
@@ -17,9 +17,7 @@ namespace fc::storage::ipfs {
    * @class LeveldbDatastore IpfsDatastore implementation based on LevelDB
    * database wrapper
    */
-  class LeveldbDatastore
-      : public IpfsDatastore,
-        public std::enable_shared_from_this<LeveldbDatastore> {
+  class LeveldbDatastore : public Ipld {
    public:
     /**
      * @brief convenience function to encode value
@@ -50,10 +48,6 @@ namespace fc::storage::ipfs {
     outcome::result<void> set(const CID &key, Value value) override;
 
     outcome::result<Value> get(const CID &key) const override;
-
-    IpldPtr shared() override {
-      return shared_from_this();
-    }
 
    private:
     std::shared_ptr<BufferMap> leveldb_;  ///< underlying db wrapper

--- a/core/storage/ipfs/impl/in_memory_datastore.hpp
+++ b/core/storage/ipfs/impl/in_memory_datastore.hpp
@@ -11,9 +11,7 @@
 
 namespace fc::storage::ipfs {
 
-  class InMemoryDatastore
-      : public IpfsDatastore,
-        public std::enable_shared_from_this<InMemoryDatastore> {
+  class InMemoryDatastore : public Ipld {
    public:
     ~InMemoryDatastore() override = default;
 
@@ -25,10 +23,6 @@ namespace fc::storage::ipfs {
 
     /** @copydoc IpfsDatastore::get() */
     outcome::result<Value> get(const CID &key) const override;
-
-    IpldPtr shared() override {
-      return shared_from_this();
-    }
 
    private:
     std::map<CID, Value> storage_;

--- a/core/storage/ipld/cids_ipld.hpp
+++ b/core/storage/ipld/cids_ipld.hpp
@@ -27,9 +27,6 @@ namespace fc::storage::ipld {
     outcome::result<bool> contains(const CID &cid) const override;
     outcome::result<void> set(const CID &cid, Buffer value) override;
     outcome::result<Buffer> get(const CID &cid) const override;
-    IpldPtr shared() override {
-      return shared_from_this();
-    }
 
     bool get(const CbCid &key, Buffer *value) const override;
     void put(const CbCid &key, BytesIn value) override;

--- a/core/storage/mpool/mpool.cpp
+++ b/core/storage/mpool/mpool.cpp
@@ -709,8 +709,8 @@ namespace fc::storage::mpool {
     if (message.signature.isBls()) {
       bls_cache.emplace(message.getCid(), message.signature);
     }
-    OUTCOME_TRY(ipld->setCbor(message));
-    OUTCOME_TRY(ipld->setCbor(message.message));
+    OUTCOME_TRY(setCbor(ipld, message));
+    OUTCOME_TRY(setCbor(ipld, message.message));
     mpool::add(by_from, message);
     signal({MpoolUpdate::Type::ADD, message});
     return outcome::success();

--- a/core/storage/unixfs/unixfs.hpp
+++ b/core/storage/unixfs/unixfs.hpp
@@ -8,8 +8,6 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::storage::unixfs {
-  using Ipld = ipfs::IpfsDatastore;
-
   constexpr size_t kMaxLinks = 1024;
   constexpr size_t kChunkSize = 1024;
 

--- a/core/vm/actor/builtin/states/impl/state_manager_impl.hpp
+++ b/core/vm/actor/builtin/states/impl/state_manager_impl.hpp
@@ -107,7 +107,7 @@ namespace fc::vm::actor::builtin::states {
     template <typename T>
     std::shared_ptr<T> createLoadedStatePtr() const {
       auto state = std::make_shared<T>();
-      ipld->load(*state);
+      cbor_blake::cbLoadT(ipld, *state);
       return state;
     }
 

--- a/core/vm/actor/builtin/states/init_actor_state_raw.hpp
+++ b/core/vm/actor/builtin/states/init_actor_state_raw.hpp
@@ -52,12 +52,12 @@ namespace fc::vm::actor {
   CBOR_TUPLE(InitActorStateRaw, address_map_cid, next_id, network_name)
 }  // namespace fc::vm::actor
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Flush<vm::actor::InitActorStateRaw> {
+  struct CbFlushT<vm::actor::InitActorStateRaw> {
     static outcome::result<void> call(vm::actor::InitActorStateRaw &state) {
       OUTCOME_TRYA(state.address_map_cid, state.address_map.flush());
       return outcome::success();
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/states/miner_actor_state.hpp
+++ b/core/vm/actor/builtin/states/miner_actor_state.hpp
@@ -8,6 +8,7 @@
 #include "vm/actor/builtin/states/state.hpp"
 
 #include "adt/array.hpp"
+#include "adt/cid_t.hpp"
 #include "adt/map.hpp"
 #include "adt/uvarint_key.hpp"
 #include "common/outcome.hpp"
@@ -51,7 +52,7 @@ namespace fc::vm::actor::builtin::states {
     TokenAmount locked_funds;
 
     /** VestingFunds (Vesting Funds schedule for the miner). */
-    CIDT<VestingFunds> vesting_funds;
+    adt::CbCidT<VestingFunds> vesting_funds;
 
     /**
      * Absolute value of debt this miner owes from unpaid fees
@@ -76,7 +77,7 @@ namespace fc::vm::actor::builtin::states {
      * Allocated sector IDs. Sector IDs can never be reused once allocated.
      * RleBitset
      */
-    CIDT<RleBitset> allocated_sectors;
+    adt::CbCidT<RleBitset> allocated_sectors;
 
     /**
      * Information for all proven and not-yet-garbage-collected sectors.
@@ -110,7 +111,7 @@ namespace fc::vm::actor::builtin::states {
      * removed at proving period boundary. Faults are not subtracted from this
      * in state, but on the fly.
      */
-    CIDT<Deadlines> deadlines;
+    adt::CbCidT<Deadlines> deadlines;
 
     /** Deadlines with outstanding fees for early sector termination. */
     RleBitset early_terminations;

--- a/core/vm/actor/builtin/states/state.hpp
+++ b/core/vm/actor/builtin/states/state.hpp
@@ -8,6 +8,11 @@
 #include "common/buffer.hpp"
 #include "common/outcome.hpp"
 
+#define ACTOR_STATE_TO_CBOR_THIS(T)                 \
+  ::fc::outcome::result<Buffer> T::toCbor() const { \
+    return ::fc::cbor_blake::cbEncodeT(*this);      \
+  }
+
 namespace fc::vm::actor::builtin::states {
   using common::Buffer;
 

--- a/core/vm/actor/builtin/states/state_provider.hpp
+++ b/core/vm/actor/builtin/states/state_provider.hpp
@@ -68,7 +68,7 @@ namespace fc::vm::actor::builtin::states {
 
     template <typename T>
     outcome::result<std::shared_ptr<T>> getStatePtr(const CID &head) const {
-      OUTCOME_TRY(state, ipld->getCbor<T>(head));
+      OUTCOME_TRY(state, getCbor<T>(ipld, head));
       return std::make_shared<T>(state);
     }
 

--- a/core/vm/actor/builtin/types/miner/bitfield_queue.hpp
+++ b/core/vm/actor/builtin/types/miner/bitfield_queue.hpp
@@ -32,13 +32,13 @@ namespace fc::vm::actor::builtin::types::miner {
 
 }  // namespace fc::vm::actor::builtin::types::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::types::miner::BitfieldQueue> {
+  struct CbVisitT<vm::actor::builtin::types::miner::BitfieldQueue> {
     template <typename Visitor>
     static void call(vm::actor::builtin::types::miner::BitfieldQueue &p,
                      const Visitor &visit) {
       visit(p.queue);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/types/miner/deadline.hpp
+++ b/core/vm/actor/builtin/types/miner/deadline.hpp
@@ -110,9 +110,9 @@ namespace fc::vm::actor::builtin::types::miner {
 
 }  // namespace fc::vm::actor::builtin::types::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::types::miner::Deadline> {
+  struct CbVisitT<vm::actor::builtin::types::miner::Deadline> {
     template <typename Visitor>
     static void call(vm::actor::builtin::types::miner::Deadline &p,
                      const Visitor &visit) {
@@ -121,4 +121,4 @@ namespace fc {
       visit(p.optimistic_post_submissions);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/types/miner/partition.hpp
+++ b/core/vm/actor/builtin/types/miner/partition.hpp
@@ -46,9 +46,9 @@ namespace fc::vm::actor::builtin::types::miner {
 
 }  // namespace fc::vm::actor::builtin::types::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::types::miner::Partition> {
+  struct CbVisitT<vm::actor::builtin::types::miner::Partition> {
     template <typename Visitor>
     static void call(vm::actor::builtin::types::miner::Partition &p,
                      const Visitor &visit) {
@@ -56,4 +56,4 @@ namespace fc {
       visit(p.early_terminated);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/types/miner/sectors.hpp
+++ b/core/vm/actor/builtin/types/miner/sectors.hpp
@@ -37,13 +37,13 @@ namespace fc::vm::actor::builtin::types::miner {
 
 }  // namespace fc::vm::actor::builtin::types::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::types::miner::Sectors> {
+  struct CbVisitT<vm::actor::builtin::types::miner::Sectors> {
     template <typename Visitor>
     static void call(vm::actor::builtin::types::miner::Sectors &p,
                      const Visitor &visit) {
       visit(p.sectors);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/types/type_manager/type_manager.hpp
+++ b/core/vm/actor/builtin/types/type_manager/type_manager.hpp
@@ -31,7 +31,7 @@ namespace fc::vm::actor::builtin::types {
       auto eq = std::make_shared<T>();
       eq->queue = expirations_epochs;
       eq->quant = quant;
-      ipld->load(*eq);
+      cbor_blake::cbLoadT(ipld, *eq);
       return eq;
     }
   };

--- a/core/vm/actor/builtin/v0/account/account_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/account/account_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::account {
-  outcome::result<Buffer> AccountActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(AccountActorState)
 }  // namespace fc::vm::actor::builtin::v0::account

--- a/core/vm/actor/builtin/v0/cron/cron_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/cron/cron_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::cron {
-  outcome::result<Buffer> CronActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(CronActorState)
 }  // namespace fc::vm::actor::builtin::v0::cron

--- a/core/vm/actor/builtin/v0/init/init_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/init/init_actor_state.cpp
@@ -8,9 +8,7 @@
 #include "vm/actor/builtin/states/init_actor_state_raw.hpp"
 
 namespace fc::vm::actor::builtin::v0::init {
-  outcome::result<Buffer> InitActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(InitActorState)
 
   outcome::result<Address> InitActorState::addActor(const Address &address) {
     return InitActorStateRaw::addActor(address_map_0.hamt, next_id, address);

--- a/core/vm/actor/builtin/v0/init/init_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/init/init_actor_state.hpp
@@ -20,13 +20,13 @@ namespace fc::vm::actor::builtin::v0::init {
   CBOR_TUPLE(InitActorState, address_map_0, next_id, network_name)
 }  // namespace fc::vm::actor::builtin::v0::init
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::init::InitActorState> {
+  struct CbVisitT<vm::actor::builtin::v0::init::InitActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v0::init::InitActorState &state,
                      const Visitor &visit) {
       visit(state.address_map_0);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/market/market_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/market/market_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::market {
-  outcome::result<Buffer> MarketActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MarketActorState)
 }  // namespace fc::vm::actor::builtin::v0::market

--- a/core/vm/actor/builtin/v0/market/market_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/market/market_actor_state.hpp
@@ -29,9 +29,9 @@ namespace fc::vm::actor::builtin::v0::market {
 
 }  // namespace fc::vm::actor::builtin::v0::market
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::market::MarketActorState> {
+  struct CbVisitT<vm::actor::builtin::v0::market::MarketActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v0::market::MarketActorState &state,
                      const Visitor &visit) {
@@ -43,4 +43,4 @@ namespace fc {
       visit(state.deals_by_epoch);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/miner/miner_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/miner/miner_actor_state.cpp
@@ -11,13 +11,11 @@ namespace fc::vm::actor::builtin::v0::miner {
   using primitives::sector::getRegisteredWindowPoStProof;
   using types::miner::kWPoStPeriodDeadlines;
 
-  outcome::result<Buffer> MinerActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MinerActorState)
 
   outcome::result<types::miner::MinerInfo> MinerActorState::getInfo(
       IpldPtr ipld) const {
-    OUTCOME_TRY(info, ipld->getCbor<MinerInfo>(miner_info));
+    OUTCOME_TRY(info, getCbor<MinerInfo>(ipld, miner_info));
     OUTCOME_TRYA(info.window_post_proof_type,
                  getRegisteredWindowPoStProof(info.seal_proof_type));
     return std::move(info);
@@ -26,21 +24,21 @@ namespace fc::vm::actor::builtin::v0::miner {
   outcome::result<void> MinerActorState::setInfo(
       IpldPtr ipld, const types::miner::MinerInfo &info) {
     MinerInfo info0{info};
-    OUTCOME_TRYA(miner_info, ipld->setCbor(info0));
+    OUTCOME_TRYA(miner_info, setCbor(ipld, info0));
     return outcome::success();
   }
 
   outcome::result<types::miner::Deadlines> MinerActorState::makeEmptyDeadlines(
       IpldPtr ipld, const CID &empty_amt_cid) {
     Deadline deadline{Deadline::makeEmpty(ipld, empty_amt_cid)};
-    OUTCOME_TRY(deadline_cid, ipld->setCbor(deadline));
+    OUTCOME_TRY(deadline_cid, setCbor(ipld, deadline));
     return types::miner::Deadlines{
         std::vector(kWPoStPeriodDeadlines, deadline_cid)};
   }
 
   outcome::result<types::miner::Deadline> MinerActorState::getDeadline(
       IpldPtr ipld, const CID &cid) const {
-    OUTCOME_TRY(deadline0, ipld->getCbor<Deadline>(cid));
+    OUTCOME_TRY(deadline0, getCbor<Deadline>(ipld, cid));
     return std::move(deadline0);
   }
 }  // namespace fc::vm::actor::builtin::v0::miner

--- a/core/vm/actor/builtin/v0/miner/miner_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/miner/miner_actor_state.hpp
@@ -41,9 +41,9 @@ namespace fc::vm::actor::builtin::v0::miner {
 
 }  // namespace fc::vm::actor::builtin::v0::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::miner::MinerActorState> {
+  struct CbVisitT<vm::actor::builtin::v0::miner::MinerActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v0::miner::MinerActorState &state,
                      const Visitor &visit) {
@@ -55,4 +55,4 @@ namespace fc {
       visit(state.deadlines);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/miner/types/expiration.hpp
+++ b/core/vm/actor/builtin/v0/miner/types/expiration.hpp
@@ -30,13 +30,13 @@ namespace fc::vm::actor::builtin::v0::miner {
   };
 }  // namespace fc::vm::actor::builtin::v0::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::miner::ExpirationQueue> {
+  struct CbVisitT<vm::actor::builtin::v0::miner::ExpirationQueue> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v0::miner::ExpirationQueue &p,
                      const Visitor &visit) {
       visit(p.queue);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/miner/types/types.hpp
+++ b/core/vm/actor/builtin/v0/miner/types/types.hpp
@@ -41,9 +41,9 @@ namespace fc::vm::actor::builtin::v0::miner {
 
 }  // namespace fc::vm::actor::builtin::v0::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::miner::Deadline> {
+  struct CbVisitT<vm::actor::builtin::v0::miner::Deadline> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v0::miner::Deadline &d,
                      const Visitor &visit) {
@@ -51,4 +51,4 @@ namespace fc {
       visit(d.expirations_epochs);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/multisig/multisig_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/multisig/multisig_actor_state.cpp
@@ -8,9 +8,7 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::multisig {
-  outcome::result<Buffer> MultisigActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MultisigActorState)
 
   std::shared_ptr<states::MultisigActorState> MultisigActorState::copy() const {
     auto copy = std::make_shared<MultisigActorState>(*this);

--- a/core/vm/actor/builtin/v0/multisig/multisig_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/multisig/multisig_actor_state.hpp
@@ -26,9 +26,9 @@ namespace fc::vm::actor::builtin::v0::multisig {
 
 }  // namespace fc::vm::actor::builtin::v0::multisig
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::multisig::MultisigActorState> {
+  struct CbVisitT<vm::actor::builtin::v0::multisig::MultisigActorState> {
     template <typename Visitor>
     static void call(
         vm::actor::builtin::v0::multisig::MultisigActorState &state,
@@ -36,4 +36,4 @@ namespace fc {
       visit(state.pending_transactions);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::payment_channel {
-  outcome::result<Buffer> PaymentChannelActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(PaymentChannelActorState)
 }  // namespace fc::vm::actor::builtin::v0::payment_channel

--- a/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_state.hpp
@@ -22,9 +22,9 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
              lanes)
 }  // namespace fc::vm::actor::builtin::v0::payment_channel
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<
+  struct CbVisitT<
       vm::actor::builtin::v0::payment_channel::PaymentChannelActorState> {
     template <typename Visitor>
     static void call(
@@ -34,4 +34,4 @@ namespace fc {
       visit(state.lanes);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/reward/reward_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/reward/reward_actor_state.cpp
@@ -16,9 +16,7 @@ namespace fc::vm::actor::builtin::v0::reward {
   using primitives::kChainEpochUndefined;
   using namespace types::reward;
 
-  outcome::result<Buffer> RewardActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(RewardActorState)
 
   void RewardActorState::initialize(
       const StoragePower &current_realized_power) {

--- a/core/vm/actor/builtin/v0/storage_power/storage_power_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/storage_power/storage_power_actor_state.cpp
@@ -13,9 +13,7 @@ namespace fc::vm::actor::builtin::v0::storage_power {
   using runtime::Runtime;
   using types::storage_power::kConsensusMinerMinPower;
 
-  outcome::result<Buffer> PowerActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(PowerActorState)
 
   std::shared_ptr<states::PowerActorState> PowerActorState::copy() const {
     auto copy = std::make_shared<PowerActorState>(*this);

--- a/core/vm/actor/builtin/v0/storage_power/storage_power_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/storage_power/storage_power_actor_state.hpp
@@ -65,9 +65,9 @@ namespace fc::vm::actor::builtin::v0::storage_power {
 
 }  // namespace fc::vm::actor::builtin::v0::storage_power
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v0::storage_power::PowerActorState> {
+  struct CbVisitT<vm::actor::builtin::v0::storage_power::PowerActorState> {
     template <typename Visitor>
     static void call(
         vm::actor::builtin::v0::storage_power::PowerActorState &state,
@@ -79,4 +79,4 @@ namespace fc {
       }
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v0/system/system_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/system/system_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::system {
-  outcome::result<Buffer> SystemActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(SystemActorState)
 }  // namespace fc::vm::actor::builtin::v0::system

--- a/core/vm/actor/builtin/v0/verified_registry/verified_registry_actor_state.cpp
+++ b/core/vm/actor/builtin/v0/verified_registry/verified_registry_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v0::verified_registry {
-  outcome::result<Buffer> VerifiedRegistryActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(VerifiedRegistryActorState)
 }  // namespace fc::vm::actor::builtin::v0::verified_registry

--- a/core/vm/actor/builtin/v0/verified_registry/verified_registry_actor_state.hpp
+++ b/core/vm/actor/builtin/v0/verified_registry/verified_registry_actor_state.hpp
@@ -16,9 +16,9 @@ namespace fc::vm::actor::builtin::v0::verified_registry {
   CBOR_TUPLE(VerifiedRegistryActorState, root_key, verifiers, verified_clients)
 }  // namespace fc::vm::actor::builtin::v0::verified_registry
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<
+  struct CbVisitT<
       vm::actor::builtin::v0::verified_registry::VerifiedRegistryActorState> {
     template <typename Visitor>
     static void call(
@@ -29,4 +29,4 @@ namespace fc {
       visit(state.verified_clients);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/account/account_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/account/account_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::account {
-  outcome::result<Buffer> AccountActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(AccountActorState)
 }  // namespace fc::vm::actor::builtin::v2::account

--- a/core/vm/actor/builtin/v2/cron/cron_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/cron/cron_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::cron {
-  outcome::result<Buffer> CronActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(CronActorState)
 }  // namespace fc::vm::actor::builtin::v2::cron

--- a/core/vm/actor/builtin/v2/init/init_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/init/init_actor_state.cpp
@@ -8,9 +8,7 @@
 #include "vm/actor/builtin/states/init_actor_state_raw.hpp"
 
 namespace fc::vm::actor::builtin::v2::init {
-  outcome::result<Buffer> InitActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(InitActorState)
 
   outcome::result<Address> InitActorState::addActor(const Address &address) {
     return InitActorStateRaw::addActor(address_map_0.hamt, next_id, address);

--- a/core/vm/actor/builtin/v2/init/init_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/init/init_actor_state.hpp
@@ -20,13 +20,13 @@ namespace fc::vm::actor::builtin::v2::init {
   CBOR_TUPLE(InitActorState, address_map_0, next_id, network_name)
 }  // namespace fc::vm::actor::builtin::v2::init
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v2::init::InitActorState> {
+  struct CbVisitT<vm::actor::builtin::v2::init::InitActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v2::init::InitActorState &state,
                      const Visitor &visit) {
       visit(state.address_map_0);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/market/market_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/market/market_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::market {
-  outcome::result<Buffer> MarketActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MarketActorState)
 }  // namespace fc::vm::actor::builtin::v2::market

--- a/core/vm/actor/builtin/v2/market/market_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/market/market_actor_state.hpp
@@ -29,9 +29,9 @@ namespace fc::vm::actor::builtin::v2::market {
 
 }  // namespace fc::vm::actor::builtin::v2::market
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v2::market::MarketActorState> {
+  struct CbVisitT<vm::actor::builtin::v2::market::MarketActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v2::market::MarketActorState &state,
                      const Visitor &visit) {
@@ -43,4 +43,4 @@ namespace fc {
       visit(state.deals_by_epoch);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/miner/miner_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/miner/miner_actor_state.cpp
@@ -11,13 +11,11 @@ namespace fc::vm::actor::builtin::v2::miner {
   using primitives::sector::getRegisteredWindowPoStProof;
   using types::miner::kWPoStPeriodDeadlines;
 
-  outcome::result<Buffer> MinerActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MinerActorState)
 
   outcome::result<types::miner::MinerInfo> MinerActorState::getInfo(
       IpldPtr ipld) const {
-    OUTCOME_TRY(info, ipld->getCbor<MinerInfo>(miner_info));
+    OUTCOME_TRY(info, getCbor<MinerInfo>(ipld, miner_info));
     OUTCOME_TRYA(info.window_post_proof_type,
                  getRegisteredWindowPoStProof(info.seal_proof_type));
     return std::move(info);
@@ -26,21 +24,21 @@ namespace fc::vm::actor::builtin::v2::miner {
   outcome::result<void> MinerActorState::setInfo(
       IpldPtr ipld, const types::miner::MinerInfo &info) {
     MinerInfo info2{info};
-    OUTCOME_TRYA(miner_info, ipld->setCbor(info2));
+    OUTCOME_TRYA(miner_info, setCbor(ipld, info2));
     return outcome::success();
   }
 
   outcome::result<types::miner::Deadlines> MinerActorState::makeEmptyDeadlines(
       IpldPtr ipld, const CID &empty_amt_cid) {
     Deadline deadline{Deadline::makeEmpty(ipld, empty_amt_cid)};
-    OUTCOME_TRY(deadline_cid, ipld->setCbor(deadline));
+    OUTCOME_TRY(deadline_cid, setCbor(ipld, deadline));
     return types::miner::Deadlines{
         std::vector(kWPoStPeriodDeadlines, deadline_cid)};
   }
 
   outcome::result<types::miner::Deadline> MinerActorState::getDeadline(
       IpldPtr ipld, const CID &cid) const {
-    OUTCOME_TRY(deadline2, ipld->getCbor<Deadline>(cid));
+    OUTCOME_TRY(deadline2, getCbor<Deadline>(ipld, cid));
     return std::move(deadline2);
   }
 }  // namespace fc::vm::actor::builtin::v2::miner

--- a/core/vm/actor/builtin/v2/miner/miner_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/miner/miner_actor_state.hpp
@@ -42,9 +42,9 @@ namespace fc::vm::actor::builtin::v2::miner {
 
 }  // namespace fc::vm::actor::builtin::v2::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v2::miner::MinerActorState> {
+  struct CbVisitT<vm::actor::builtin::v2::miner::MinerActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v2::miner::MinerActorState &state,
                      const Visitor &visit) {
@@ -56,4 +56,4 @@ namespace fc {
       visit(state.deadlines);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/miner/types/expiration.hpp
+++ b/core/vm/actor/builtin/v2/miner/types/expiration.hpp
@@ -44,13 +44,13 @@ namespace fc::vm::actor::builtin::v2::miner {
   };
 }  // namespace fc::vm::actor::builtin::v2::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v2::miner::ExpirationQueue> {
+  struct CbVisitT<vm::actor::builtin::v2::miner::ExpirationQueue> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v2::miner::ExpirationQueue &p,
                      const Visitor &visit) {
       visit(p.queue);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/multisig/multisig_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/multisig/multisig_actor_state.cpp
@@ -8,9 +8,7 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::multisig {
-  outcome::result<Buffer> MultisigActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MultisigActorState)
 
   std::shared_ptr<states::MultisigActorState> MultisigActorState::copy() const {
     auto copy = std::make_shared<MultisigActorState>(*this);

--- a/core/vm/actor/builtin/v2/multisig/multisig_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/multisig/multisig_actor_state.hpp
@@ -26,9 +26,9 @@ namespace fc::vm::actor::builtin::v2::multisig {
 
 }  // namespace fc::vm::actor::builtin::v2::multisig
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v2::multisig::MultisigActorState> {
+  struct CbVisitT<vm::actor::builtin::v2::multisig::MultisigActorState> {
     template <typename Visitor>
     static void call(
         vm::actor::builtin::v2::multisig::MultisigActorState &state,
@@ -36,4 +36,4 @@ namespace fc {
       visit(state.pending_transactions);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/payment_channel/payment_channel_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/payment_channel/payment_channel_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::payment_channel {
-  outcome::result<Buffer> PaymentChannelActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(PaymentChannelActorState)
 }  // namespace fc::vm::actor::builtin::v2::payment_channel

--- a/core/vm/actor/builtin/v2/payment_channel/payment_channel_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/payment_channel/payment_channel_actor_state.hpp
@@ -22,9 +22,9 @@ namespace fc::vm::actor::builtin::v2::payment_channel {
              lanes)
 }  // namespace fc::vm::actor::builtin::v2::payment_channel
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<
+  struct CbVisitT<
       vm::actor::builtin::v2::payment_channel::PaymentChannelActorState> {
     template <typename Visitor>
     static void call(
@@ -34,4 +34,4 @@ namespace fc {
       visit(state.lanes);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/reward/reward_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/reward/reward_actor_state.cpp
@@ -15,9 +15,7 @@ namespace fc::vm::actor::builtin::v2::reward {
   using primitives::kChainEpochUndefined;
   using namespace types::reward;
 
-  outcome::result<Buffer> RewardActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(RewardActorState)
 
   void RewardActorState::initialize(
       const StoragePower &current_realized_power) {

--- a/core/vm/actor/builtin/v2/storage_power/storage_power_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/storage_power/storage_power_actor_state.cpp
@@ -13,9 +13,7 @@ namespace fc::vm::actor::builtin::v2::storage_power {
   using runtime::Runtime;
   using types::storage_power::kConsensusMinerMinPower;
 
-  outcome::result<Buffer> PowerActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(PowerActorState)
 
   std::shared_ptr<states::PowerActorState> PowerActorState::copy() const {
     auto copy = std::make_shared<PowerActorState>(*this);

--- a/core/vm/actor/builtin/v2/storage_power/storage_power_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/storage_power/storage_power_actor_state.hpp
@@ -66,9 +66,9 @@ namespace fc::vm::actor::builtin::v2::storage_power {
 
 }  // namespace fc::vm::actor::builtin::v2::storage_power
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v2::storage_power::PowerActorState> {
+  struct CbVisitT<vm::actor::builtin::v2::storage_power::PowerActorState> {
     template <typename Visitor>
     static void call(
         vm::actor::builtin::v2::storage_power::PowerActorState &state,
@@ -80,4 +80,4 @@ namespace fc {
       }
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v2/system/system_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/system/system_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::system {
-  outcome::result<Buffer> SystemActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(SystemActorState)
 }  // namespace fc::vm::actor::builtin::v2::system

--- a/core/vm/actor/builtin/v2/verified_registry/verified_registry_actor_state.cpp
+++ b/core/vm/actor/builtin/v2/verified_registry/verified_registry_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v2::verified_registry {
-  outcome::result<Buffer> VerifiedRegistryActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(VerifiedRegistryActorState)
 }  // namespace fc::vm::actor::builtin::v2::verified_registry

--- a/core/vm/actor/builtin/v2/verified_registry/verified_registry_actor_state.hpp
+++ b/core/vm/actor/builtin/v2/verified_registry/verified_registry_actor_state.hpp
@@ -16,9 +16,9 @@ namespace fc::vm::actor::builtin::v2::verified_registry {
   CBOR_TUPLE(VerifiedRegistryActorState, root_key, verifiers, verified_clients)
 }  // namespace fc::vm::actor::builtin::v2::verified_registry
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<
+  struct CbVisitT<
       vm::actor::builtin::v2::verified_registry::VerifiedRegistryActorState> {
     template <typename Visitor>
     static void call(
@@ -29,4 +29,4 @@ namespace fc {
       visit(state.verified_clients);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/account/account_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/account/account_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::account {
-  outcome::result<Buffer> AccountActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(AccountActorState)
 }  // namespace fc::vm::actor::builtin::v3::account

--- a/core/vm/actor/builtin/v3/cron/cron_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/cron/cron_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::cron {
-  outcome::result<Buffer> CronActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(CronActorState)
 }  // namespace fc::vm::actor::builtin::v3::cron

--- a/core/vm/actor/builtin/v3/init/init_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/init/init_actor_state.cpp
@@ -8,9 +8,7 @@
 #include "vm/actor/builtin/states/init_actor_state_raw.hpp"
 
 namespace fc::vm::actor::builtin::v3::init {
-  outcome::result<Buffer> InitActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(InitActorState)
 
   outcome::result<Address> InitActorState::addActor(const Address &address) {
     return InitActorStateRaw::addActor(address_map_3.hamt, next_id, address);

--- a/core/vm/actor/builtin/v3/init/init_actor_state.hpp
+++ b/core/vm/actor/builtin/v3/init/init_actor_state.hpp
@@ -20,13 +20,13 @@ namespace fc::vm::actor::builtin::v3::init {
   CBOR_TUPLE(InitActorState, address_map_3, next_id, network_name)
 }  // namespace fc::vm::actor::builtin::v3::init
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v3::init::InitActorState> {
+  struct CbVisitT<vm::actor::builtin::v3::init::InitActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v3::init::InitActorState &state,
                      const Visitor &visit) {
       visit(state.address_map_3);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/miner/miner_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/miner/miner_actor_state.cpp
@@ -10,34 +10,32 @@
 namespace fc::vm::actor::builtin::v3::miner {
   using types::miner::kWPoStPeriodDeadlines;
 
-  outcome::result<Buffer> MinerActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MinerActorState)
 
   outcome::result<types::miner::MinerInfo> MinerActorState::getInfo(
       IpldPtr ipld) const {
-    OUTCOME_TRY(info3, ipld->getCbor<MinerInfo>(miner_info));
+    OUTCOME_TRY(info3, getCbor<MinerInfo>(ipld, miner_info));
     return std::move(info3);
   }
 
   outcome::result<void> MinerActorState::setInfo(
       IpldPtr ipld, const types::miner::MinerInfo &info) {
     MinerInfo info3{info};
-    OUTCOME_TRYA(miner_info, ipld->setCbor(info3));
+    OUTCOME_TRYA(miner_info, setCbor(ipld, info3));
     return outcome::success();
   }
 
   outcome::result<types::miner::Deadlines> MinerActorState::makeEmptyDeadlines(
       IpldPtr ipld, const CID &empty_amt_cid) {
     Deadline deadline{Deadline::makeEmpty(ipld, empty_amt_cid)};
-    OUTCOME_TRY(deadline_cid, ipld->setCbor(deadline));
+    OUTCOME_TRY(deadline_cid, setCbor(ipld, deadline));
     return types::miner::Deadlines{
         std::vector(kWPoStPeriodDeadlines, deadline_cid)};
   }
 
   outcome::result<types::miner::Deadline> MinerActorState::getDeadline(
       IpldPtr ipld, const CID &cid) const {
-    OUTCOME_TRY(deadline3, ipld->getCbor<Deadline>(cid));
+    OUTCOME_TRY(deadline3, getCbor<Deadline>(ipld, cid));
     return std::move(deadline3);
   }
 }  // namespace fc::vm::actor::builtin::v3::miner

--- a/core/vm/actor/builtin/v3/miner/miner_actor_state.hpp
+++ b/core/vm/actor/builtin/v3/miner/miner_actor_state.hpp
@@ -42,9 +42,9 @@ namespace fc::vm::actor::builtin::v3::miner {
 
 }  // namespace fc::vm::actor::builtin::v3::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v3::miner::MinerActorState> {
+  struct CbVisitT<vm::actor::builtin::v3::miner::MinerActorState> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v3::miner::MinerActorState &state,
                      const Visitor &visit) {
@@ -56,4 +56,4 @@ namespace fc {
       visit(state.deadlines);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/miner/types/types.hpp
+++ b/core/vm/actor/builtin/v3/miner/types/types.hpp
@@ -44,9 +44,9 @@ namespace fc::vm::actor::builtin::v3::miner {
 
 }  // namespace fc::vm::actor::builtin::v3::miner
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v3::miner::Deadline> {
+  struct CbVisitT<vm::actor::builtin::v3::miner::Deadline> {
     template <typename Visitor>
     static void call(vm::actor::builtin::v3::miner::Deadline &d,
                      const Visitor &visit) {
@@ -55,4 +55,4 @@ namespace fc {
       visit(d.optimistic_post_submissions);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/multisig/multisig_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/multisig/multisig_actor_state.cpp
@@ -8,9 +8,7 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::multisig {
-  outcome::result<Buffer> MultisigActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(MultisigActorState)
 
   std::shared_ptr<states::MultisigActorState> MultisigActorState::copy() const {
     auto copy = std::make_shared<MultisigActorState>(*this);

--- a/core/vm/actor/builtin/v3/multisig/multisig_actor_state.hpp
+++ b/core/vm/actor/builtin/v3/multisig/multisig_actor_state.hpp
@@ -26,9 +26,9 @@ namespace fc::vm::actor::builtin::v3::multisig {
 
 }  // namespace fc::vm::actor::builtin::v3::multisig
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v3::multisig::MultisigActorState> {
+  struct CbVisitT<vm::actor::builtin::v3::multisig::MultisigActorState> {
     template <typename Visitor>
     static void call(
         vm::actor::builtin::v3::multisig::MultisigActorState &state,
@@ -36,4 +36,4 @@ namespace fc {
       visit(state.pending_transactions);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::payment_channel {
-  outcome::result<Buffer> PaymentChannelActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(PaymentChannelActorState)
 }  // namespace fc::vm::actor::builtin::v3::payment_channel

--- a/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_state.hpp
+++ b/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_state.hpp
@@ -22,9 +22,9 @@ namespace fc::vm::actor::builtin::v3::payment_channel {
              lanes)
 }  // namespace fc::vm::actor::builtin::v3::payment_channel
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<
+  struct CbVisitT<
       vm::actor::builtin::v3::payment_channel::PaymentChannelActorState> {
     template <typename Visitor>
     static void call(
@@ -34,4 +34,4 @@ namespace fc {
       visit(state.lanes);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/storage_power/storage_power_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/storage_power/storage_power_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::storage_power {
-  outcome::result<Buffer> PowerActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(PowerActorState)
 }  // namespace fc::vm::actor::builtin::v3::storage_power

--- a/core/vm/actor/builtin/v3/storage_power/storage_power_actor_state.hpp
+++ b/core/vm/actor/builtin/v3/storage_power/storage_power_actor_state.hpp
@@ -33,9 +33,9 @@ namespace fc::vm::actor::builtin::v3::storage_power {
 
 }  // namespace fc::vm::actor::builtin::v3::storage_power
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<vm::actor::builtin::v3::storage_power::PowerActorState> {
+  struct CbVisitT<vm::actor::builtin::v3::storage_power::PowerActorState> {
     template <typename Visitor>
     static void call(
         vm::actor::builtin::v3::storage_power::PowerActorState &state,
@@ -47,4 +47,4 @@ namespace fc {
       }
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/actor/builtin/v3/system/system_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/system/system_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::system {
-  outcome::result<Buffer> SystemActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(SystemActorState)
 }  // namespace fc::vm::actor::builtin::v3::system

--- a/core/vm/actor/builtin/v3/verified_registry/verified_registry_actor_state.cpp
+++ b/core/vm/actor/builtin/v3/verified_registry/verified_registry_actor_state.cpp
@@ -8,7 +8,5 @@
 #include "storage/ipfs/datastore.hpp"
 
 namespace fc::vm::actor::builtin::v3::verified_registry {
-  outcome::result<Buffer> VerifiedRegistryActorState::toCbor() const {
-    return Ipld::encode(*this);
-  }
+  ACTOR_STATE_TO_CBOR_THIS(VerifiedRegistryActorState)
 }  // namespace fc::vm::actor::builtin::v3::verified_registry

--- a/core/vm/actor/builtin/v3/verified_registry/verified_registry_actor_state.hpp
+++ b/core/vm/actor/builtin/v3/verified_registry/verified_registry_actor_state.hpp
@@ -16,9 +16,9 @@ namespace fc::vm::actor::builtin::v3::verified_registry {
   CBOR_TUPLE(VerifiedRegistryActorState, root_key, verifiers, verified_clients)
 }  // namespace fc::vm::actor::builtin::v3::verified_registry
 
-namespace fc {
+namespace fc::cbor_blake {
   template <>
-  struct Ipld::Visit<
+  struct CbVisitT<
       vm::actor::builtin::v3::verified_registry::VerifiedRegistryActorState> {
     template <typename Visitor>
     static void call(
@@ -29,4 +29,4 @@ namespace fc {
       visit(state.verified_clients);
     }
   };
-}  // namespace fc
+}  // namespace fc::cbor_blake

--- a/core/vm/interpreter/impl/interpreter_impl.cpp
+++ b/core/vm/interpreter/impl/interpreter_impl.cpp
@@ -148,7 +148,7 @@ namespace fc::vm::interpreter {
     OUTCOME_TRY(new_state_root, env->state_tree->flush());
     OUTCOME_TRY(env->ipld->flush(new_state_root));
 
-    OUTCOME_TRY(Ipld::flush(receipts));
+    OUTCOME_TRY(receipts.amt.flush());
 
     OUTCOME_TRY(weight, getWeight(tipset));
 

--- a/core/vm/runtime/circulating.cpp
+++ b/core/vm/runtime/circulating.cpp
@@ -35,7 +35,7 @@ namespace fc::vm {
   outcome::result<std::shared_ptr<Circulating>> Circulating::make(
       IpldPtr ipld, const CID &genesis) {
     auto circulating{std::make_shared<Circulating>()};
-    OUTCOME_TRY(block, ipld->getCbor<primitives::block::BlockHeader>(genesis));
+    OUTCOME_TRY(block, getCbor<primitives::block::BlockHeader>(ipld, genesis));
     OUTCOME_TRYA(circulating->genesis,
                  getLocked(std::make_shared<state::StateTreeImpl>(
                      ipld, block.parent_state_root)));

--- a/core/vm/runtime/env.hpp
+++ b/core/vm/runtime/env.hpp
@@ -34,15 +34,13 @@ namespace fc::vm::runtime {
                                       const Address &address,
                                       bool allow_actor = true);
 
-  struct IpldBuffered : public Ipld,
-                        public std::enable_shared_from_this<IpldBuffered> {
+  struct IpldBuffered : public Ipld {
     IpldBuffered(IpldPtr ipld);
     outcome::result<void> flush(const CID &root);
 
     outcome::result<bool> contains(const CID &key) const override;
     outcome::result<void> set(const CID &key, Value value) override;
     outcome::result<Value> get(const CID &key) const override;
-    IpldPtr shared() override;
 
     IpldPtr ipld;
     // vm only stores "DAG_CBOR blake2b_256" cids
@@ -100,17 +98,13 @@ namespace fc::vm::runtime {
     size_t actors_created{};
   };
 
-  struct ChargingIpld : public Ipld,
-                        public std::enable_shared_from_this<ChargingIpld> {
+  struct ChargingIpld : public Ipld {
     ChargingIpld(std::weak_ptr<Execution> execution) : execution_{execution} {}
     outcome::result<bool> contains(const CID &key) const override {
       throw "not implemented";
     }
     outcome::result<void> set(const CID &key, Value value) override;
     outcome::result<Value> get(const CID &key) const override;
-    IpldPtr shared() override {
-      return shared_from_this();
-    }
 
     std::weak_ptr<Execution> execution_;
   };

--- a/core/vm/runtime/impl/env.cpp
+++ b/core/vm/runtime/impl/env.cpp
@@ -96,10 +96,6 @@ namespace fc::vm::runtime {
     return storage::ipfs::IpfsDatastoreError::kNotFound;
   }
 
-  IpldPtr IpldBuffered::shared() {
-    return shared_from_this();
-  }
-
   Env::Env(const EnvironmentContext &env_context,
            TsBranchPtr ts_branch,
            TipsetCPtr tipset)

--- a/test/core/adt/multimap_test.cpp
+++ b/test/core/adt/multimap_test.cpp
@@ -80,7 +80,7 @@ TEST_F(MultimapTest, AppendAndVisit) {
  */
 TEST_F(MultimapTest, ReloadFromCid) {
   appendValues();
-  EXPECT_OUTCOME_TRUE_1(fc::Ipld::flush(mmap));
+  EXPECT_OUTCOME_TRUE_1(mmap.hamt.flush());
   mmap = {mmap.hamt.cid(), ipld};
   expectVisitValues();
 }

--- a/test/core/codec/cbor/cbor_test.cpp
+++ b/test/core/codec/cbor/cbor_test.cpp
@@ -373,7 +373,7 @@ TEST(CborDecoder, FlatErrors) {
   int i;
   EXPECT_OUTCOME_RAISE(CborDecodeError::kWrongType,
                        CborDecodeStream("01"_unhex).list() >> i >> i);
-  EXPECT_OUTCOME_RAISE(CborDecodeError::kWrongType,
+  EXPECT_OUTCOME_RAISE(CborDecodeError::kInvalidCbor,
                        CborDecodeStream("80"_unhex).list() >> i);
 }
 

--- a/test/core/codec/cbor/light_reader/light_actor_reader.cpp
+++ b/test/core/codec/cbor/light_reader/light_actor_reader.cpp
@@ -41,7 +41,7 @@ namespace fc::codec::cbor::light_reader {
     template <typename T>
     T makeSomeMinerActorState() {
       T state;
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       MinerInfo info;
       info.window_post_partition_sectors = 100;
       info.sector_size = 101;
@@ -68,11 +68,11 @@ namespace fc::codec::cbor::light_reader {
    */
   TEST_F(LightActorReader, MinerActorV0) {
     auto state = makeSomeMinerActorState<MinerActorStateV0>();
-    EXPECT_OUTCOME_TRUE(state_root, ipld->setCbor(state));
+    EXPECT_OUTCOME_TRUE(state_root, setCbor(ipld, state));
 
     CID expected_miner_info = state.miner_info;
     CID expected_sectors = state.sectors.amt.cid();
-    CID expected_deadlines = state.deadlines;
+    CID expected_deadlines = state.deadlines.cid;
     EXPECT_OUTCOME_TRUE(
         actual, readMinerActorInfo(light_ipld, *asBlake(state_root), true));
     const auto [actual_miner_info, actual_sectors, actual_deadlines] = actual;
@@ -89,11 +89,11 @@ namespace fc::codec::cbor::light_reader {
    */
   TEST_F(LightActorReader, MinerActorV2) {
     auto state = makeSomeMinerActorState<MinerActorStateV2>();
-    EXPECT_OUTCOME_TRUE(state_root, ipld->setCbor(state));
+    EXPECT_OUTCOME_TRUE(state_root, setCbor(ipld, state));
 
     CID expected_miner_info = state.miner_info;
     CID expected_sectors = state.sectors.amt.cid();
-    CID expected_deadlines = state.deadlines;
+    CID expected_deadlines = state.deadlines.cid;
     EXPECT_OUTCOME_TRUE(
         actual, readMinerActorInfo(light_ipld, *asBlake(state_root), false));
     const auto [actual_miner_info, actual_sectors, actual_deadlines] = actual;
@@ -109,14 +109,14 @@ namespace fc::codec::cbor::light_reader {
    */
   TEST_F(LightActorReader, PowerActorV0) {
     PowerActorStateV0 state;
-    ipld->load(state);
+    cbor_blake::cbLoadT(ipld, state);
     primitives::address::Address address =
         primitives::address::Address::makeFromId(100);
     ClaimV0 claim;
     claim.raw_power = 101;
     claim.qa_power = 102;
     EXPECT_OUTCOME_TRUE_1(state.claims0.set(address, claim));
-    EXPECT_OUTCOME_TRUE(state_root, ipld->setCbor(state));
+    EXPECT_OUTCOME_TRUE(state_root, setCbor(ipld, state));
 
     auto expected = state.claims0.hamt.cid();
     EXPECT_OUTCOME_TRUE(
@@ -132,7 +132,7 @@ namespace fc::codec::cbor::light_reader {
    */
   TEST_F(LightActorReader, PowerActorV2) {
     PowerActorStateV2 state;
-    ipld->load(state);
+    cbor_blake::cbLoadT(ipld, state);
     primitives::address::Address address =
         primitives::address::Address::makeFromId(100);
     ClaimV2 claim;
@@ -140,7 +140,7 @@ namespace fc::codec::cbor::light_reader {
     claim.raw_power = 101;
     claim.qa_power = 102;
     EXPECT_OUTCOME_TRUE_1(state.claims2.set(address, claim));
-    EXPECT_OUTCOME_TRUE(state_root, ipld->setCbor(state));
+    EXPECT_OUTCOME_TRUE(state_root, setCbor(ipld, state));
 
     auto expected = state.claims2.hamt.cid();
     EXPECT_OUTCOME_TRUE(

--- a/test/core/markets/retrieval/fixture.hpp
+++ b/test/core/markets/retrieval/fixture.hpp
@@ -215,7 +215,7 @@ namespace fc::markets::retrieval::test {
       OUTCOME_TRY(piece_storage->addDealForPiece(piece_cid, deal));
       OUTCOME_TRY(piece_storage->addPayloadLocations(
           piece_cid, {{payload_cid, location}}));
-      OUTCOME_TRY(ipfs->setCbor(payload));
+      OUTCOME_TRY(setCbor(ipfs, payload));
       return outcome::success();
     }
   };

--- a/test/core/markets/storage/chain_events/chain_events_test.cpp
+++ b/test/core/markets/storage/chain_events/chain_events_test.cpp
@@ -16,7 +16,6 @@ namespace fc::markets::storage::chain_events {
   using api::Chan;
   using api::FullNodeApi;
   using fc::storage::ipfs::InMemoryDatastore;
-  using fc::storage::ipfs::IpfsDatastore;
   using primitives::block::BlockHeader;
   using primitives::block::MsgMeta;
   using primitives::tipset::HeadChange;

--- a/test/core/miner/checks_test.cpp
+++ b/test/core/miner/checks_test.cpp
@@ -610,7 +610,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -745,7 +745,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -845,7 +845,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -909,7 +909,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -974,7 +974,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -1039,7 +1039,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -1122,7 +1122,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {
@@ -1203,7 +1203,7 @@ namespace fc::mining::checks {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {

--- a/test/core/miner/sealing_test.cpp
+++ b/test/core/miner/sealing_test.cpp
@@ -730,7 +730,7 @@ namespace fc::mining {
         return codec::cbor::encode(actor_state);
       }
       if (key == cid_root) {
-        OUTCOME_TRY(root, ipld->getCbor<storage::hamt::Node>(cid_root));
+        OUTCOME_TRY(root, getCbor<storage::hamt::Node>(ipld, cid_root));
         return codec::cbor::encode(root);
       }
       if (key == actor_state.allocated_sectors) {

--- a/test/core/storage/amt/amt_test.cpp
+++ b/test/core/storage/amt/amt_test.cpp
@@ -24,7 +24,7 @@ using fc::storage::ipfs::InMemoryDatastore;
 class AmtTest : public ::testing::Test {
  public:
   auto getRoot() {
-    return store->getCbor<Root>(amt.flush().value()).value();
+    return fc::getCbor<Root>(store, amt.flush().value()).value();
   }
 
   std::shared_ptr<InMemoryDatastore> store{

--- a/test/core/storage/car/car_test.cpp
+++ b/test/core/storage/car/car_test.cpp
@@ -105,22 +105,23 @@ struct Sample2 {
 CBOR_TUPLE(Sample2, i)
 
 TEST(CarTest, Writer) {
-  InMemoryDatastore ipld1;
+  using fc::setCbor;
+  auto ipld1{std::make_shared<InMemoryDatastore>()};
   Sample2 obj2{2}, obj3{3};
-  EXPECT_OUTCOME_TRUE(cid2, ipld1.setCbor(obj2));
-  EXPECT_OUTCOME_TRUE(cid3, ipld1.setCbor(obj3));
+  EXPECT_OUTCOME_TRUE(cid2, setCbor(ipld1, obj2));
+  EXPECT_OUTCOME_TRUE(cid3, setCbor(ipld1, obj3));
   Sample1 obj1{{cid2}, {{"a", cid3}}};
-  EXPECT_OUTCOME_TRUE(root, ipld1.setCbor(obj1));
-  EXPECT_OUTCOME_TRUE(car, makeCar(ipld1, {root}));
+  EXPECT_OUTCOME_TRUE(root, setCbor(ipld1, obj1));
+  EXPECT_OUTCOME_TRUE(car, makeCar(*ipld1, {root}));
 
   InMemoryDatastore ipld2;
   EXPECT_OUTCOME_TRUE(roots, loadCar(ipld2, car));
   EXPECT_THAT(roots, testing::ElementsAre(root));
-  EXPECT_OUTCOME_TRUE(raw1, ipld1.get(root));
+  EXPECT_OUTCOME_TRUE(raw1, ipld1->get(root));
   EXPECT_OUTCOME_EQ(ipld2.get(root), raw1);
-  EXPECT_OUTCOME_TRUE(raw2, ipld1.get(cid2));
+  EXPECT_OUTCOME_TRUE(raw2, ipld1->get(cid2));
   EXPECT_OUTCOME_EQ(ipld2.get(cid2), raw2);
-  EXPECT_OUTCOME_TRUE(raw3, ipld1.get(cid3));
+  EXPECT_OUTCOME_TRUE(raw3, ipld1->get(cid3));
   EXPECT_OUTCOME_EQ(ipld2.get(cid3), raw3);
 }
 

--- a/test/core/storage/car/cids_index_test.cpp
+++ b/test/core/storage/car/cids_index_test.cpp
@@ -53,20 +53,20 @@ namespace fc::storage::cids_index {
 
     // readable car can't write
     ipld = *load(false);
-    EXPECT_OUTCOME_FALSE_1(ipld->setCbor(value1));
+    EXPECT_OUTCOME_FALSE_1(setCbor(ipld, value1));
 
     // writeable car can write
     ipld = *load(true);
-    EXPECT_OUTCOME_TRUE_1(ipld->setCbor(value1));
-    EXPECT_OUTCOME_EQ(ipld->getCbor<decltype(value1)>(cid1), value1);
+    EXPECT_OUTCOME_TRUE_1(setCbor(ipld, value1));
+    EXPECT_OUTCOME_EQ(getCbor<decltype(value1)>(ipld, cid1), value1);
 
     // value persists
     ipld = *load(true);
-    EXPECT_OUTCOME_EQ(ipld->getCbor<decltype(value1)>(cid1), value1);
+    EXPECT_OUTCOME_EQ(getCbor<decltype(value1)>(ipld, cid1), value1);
 
     // inserted only once
     auto car_value1{*common::readFile(car_path)};
-    EXPECT_OUTCOME_TRUE_1(ipld->setCbor(value1));
+    EXPECT_OUTCOME_TRUE_1(setCbor(ipld, value1));
     ipld->writable.flush();
     EXPECT_EQ(fs::file_size(car_path), car_value1.size());
 
@@ -76,34 +76,34 @@ namespace fc::storage::cids_index {
     EXPECT_OUTCOME_EQ(ipld->contains(cid1), false);
 
     // changed car drops index
-    EXPECT_OUTCOME_TRUE_1(ipld->setCbor(value2));
+    EXPECT_OUTCOME_TRUE_1(setCbor(ipld, value2));
     ipld = *load(true);
-    EXPECT_OUTCOME_EQ(ipld->getCbor<decltype(value2)>(cid2), value2);
+    EXPECT_OUTCOME_EQ(getCbor<decltype(value2)>(ipld, cid2), value2);
     *common::writeFile(car_path, car_value1);
     ipld = *load(true);
     EXPECT_OUTCOME_EQ(ipld->contains(cid2), false);
-    EXPECT_OUTCOME_EQ(ipld->getCbor<decltype(value1)>(cid1), value1);
+    EXPECT_OUTCOME_EQ(getCbor<decltype(value1)>(ipld, cid1), value1);
 
     // incomplete car is truncated
     std::ofstream{car_path, std::ios::app | std::ios::binary} << "\x01";
     EXPECT_EQ(fs::file_size(car_path), car_value1.size() + 1);
     ipld = *load(true);
-    EXPECT_OUTCOME_EQ(ipld->getCbor<decltype(value1)>(cid1), value1);
+    EXPECT_OUTCOME_EQ(getCbor<decltype(value1)>(ipld, cid1), value1);
     EXPECT_EQ(fs::file_size(car_path), car_value1.size());
 
     // index is merged
-    EXPECT_OUTCOME_TRUE_1(ipld->setCbor(value2));
+    EXPECT_OUTCOME_TRUE_1(setCbor(ipld, value2));
     ipld = *load(true);
   }
 
   TEST_F(CidsIndexTest, FlushOn) {
     ipld = *load(true);
     ipld->flush_on = 3;
-    ipld->setCbor(1).value();
+    setCbor(ipld, 1).value();
     EXPECT_EQ(ipld->written.size(), 1);
-    ipld->setCbor(2).value();
+    setCbor(ipld, 2).value();
     EXPECT_EQ(ipld->written.size(), 2);
-    ipld->setCbor(3).value();
+    setCbor(ipld, 3).value();
     EXPECT_EQ(ipld->written.size(), 0);
   }
 
@@ -113,7 +113,7 @@ namespace fc::storage::cids_index {
     ipld->flush_on = 5;
     std::vector<CID> cids;
     for (auto i{0}; i < 40; ++i) {
-      ipld->setCbor(i).value();
+      setCbor(ipld, i).value();
     }
     if (io) {
       std::promise<void> wait;
@@ -121,7 +121,7 @@ namespace fc::storage::cids_index {
       wait.get_future().get();
     }
     for (auto i{0}; i < (int)cids.size(); ++i) {
-      EXPECT_OUTCOME_EQ(ipld->getCbor<int>(cids[i]), i);
+      EXPECT_OUTCOME_EQ(getCbor<int>(ipld, cids[i]), i);
     }
   }
 

--- a/test/core/storage/car/compacter_test.cpp
+++ b/test/core/storage/car/compacter_test.cpp
@@ -58,10 +58,9 @@ namespace fc::storage::compacter {
                        old_ipld,
                        std::make_shared<std::shared_mutex>());
 
-      auto meta{
-          old_ipld
-              ->getCbor<CompacterTestMeta>(car::readHeader(old_car).value()[0])
-              .value()};
+      auto meta{getCbor<CompacterTestMeta>(old_ipld,
+                                           car::readHeader(old_car).value()[0])
+                    .value()};
       const auto ts_load{std::make_shared<primitives::tipset::TsLoadIpld>(
           std::make_shared<CbAsAnyIpld>(compacter))};
       head = ts_load->load(meta.ts_main).value();

--- a/test/core/storage/ipfs/datastore_integration_test.cpp
+++ b/test/core/storage/ipfs/datastore_integration_test.cpp
@@ -13,7 +13,6 @@
 
 using fc::CID;
 using fc::common::Buffer;
-using fc::storage::ipfs::IpfsDatastore;
 using fc::storage::ipfs::IpfsDatastoreError;
 using fc::storage::ipfs::LeveldbDatastore;
 using libp2p::multi::HashType;

--- a/test/core/vm/actor/builtin/types/miner/bitfield_queue_test.cpp
+++ b/test/core/vm/actor/builtin/types/miner/bitfield_queue_test.cpp
@@ -14,8 +14,8 @@ namespace fc::vm::actor::builtin::types::miner {
 
   struct BitfieldQueueTest : testing::Test {
     void SetUp() override {
-      ipld->load(expected);
-      ipld->load(queue);
+      cbor_blake::cbLoadT(ipld, expected);
+      cbor_blake::cbLoadT(ipld, queue);
     }
 
     std::shared_ptr<InMemoryDatastore> ipld{

--- a/test/core/vm/actor/builtin/types/miner/expiration_queue_v0_test.cpp
+++ b/test/core/vm/actor/builtin/types/miner/expiration_queue_v0_test.cpp
@@ -24,7 +24,7 @@ namespace fc::vm::actor::builtin::v0::miner {
   struct ExpirationQueueTestV0 : testing::Test {
     void SetUp() override {
       eq.quant = types::miner::kNoQuantization;
-      ipld->load(eq);
+      cbor_blake::cbLoadT(ipld, eq);
 
       sectors = {testSector(2, 1, 50, 60, 1000),
                  testSector(3, 2, 51, 61, 1001),

--- a/test/core/vm/actor/builtin/types/miner/expiration_queue_v2_test.cpp
+++ b/test/core/vm/actor/builtin/types/miner/expiration_queue_v2_test.cpp
@@ -24,7 +24,7 @@ namespace fc::vm::actor::builtin::v2::miner {
   struct ExpirationQueueTestV2 : testing::Test {
     void SetUp() override {
       eq.quant = types::miner::kNoQuantization;
-      ipld->load(eq);
+      cbor_blake::cbLoadT(ipld, eq);
 
       sectors = {testSector(2, 1, 50, 60, 1000),
                  testSector(3, 2, 51, 61, 1001),

--- a/test/core/vm/actor/builtin/types/miner/expiration_queue_v3_test.cpp
+++ b/test/core/vm/actor/builtin/types/miner/expiration_queue_v3_test.cpp
@@ -26,7 +26,7 @@ namespace fc::vm::actor::builtin::v3::miner {
   struct ExpirationQueueTestV3 : testing::Test {
     void SetUp() override {
       eq.quant = types::miner::kNoQuantization;
-      ipld->load(eq);
+      cbor_blake::cbLoadT(ipld, eq);
 
       sectors = {testSector(2, 1, 50, 60, 1000),
                  testSector(3, 2, 51, 61, 1001),

--- a/test/core/vm/actor/builtin/types/miner/sectors_test.cpp
+++ b/test/core/vm/actor/builtin/types/miner/sectors_test.cpp
@@ -16,7 +16,7 @@ namespace fc::vm::actor::builtin::types::miner {
 
   struct SectorsTest : testing::Test {
     void SetUp() override {
-      ipld->load(setup_sectors);
+      cbor_blake::cbLoadT(ipld, setup_sectors);
 
       EXPECT_OUTCOME_TRUE_1(
           setup_sectors.store({makeSector(0), makeSector(1), makeSector(5)}));

--- a/test/core/vm/actor/builtin/v0/account/account_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/account/account_actor_test.cpp
@@ -28,9 +28,9 @@ namespace fc::vm::actor::builtin::v0::account {
 
       EXPECT_CALL(*state_manager, getAccountActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<AccountActorState>(cid));
+                                getCbor<AccountActorState>(ipld, cid));
             auto s = std::make_shared<AccountActorState>(current_state);
             return std::static_pointer_cast<states::AccountActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v0/cron/cron_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/cron/cron_actor_test.cpp
@@ -30,9 +30,9 @@ namespace fc::vm::actor::builtin::v0::cron {
 
       EXPECT_CALL(*state_manager, getCronActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<CronActorState>(cid));
+                                getCbor<CronActorState>(ipld, cid));
             auto s = std::make_shared<CronActorState>(current_state);
             return std::static_pointer_cast<states::CronActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v0/init/init_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/init/init_actor_test.cpp
@@ -25,21 +25,21 @@ namespace fc::vm::actor::builtin::v0::init {
   struct InitActorTest : public ActorTestFixture<InitActorState> {
     void SetUp() override {
       ActorTestFixture<InitActorState>::SetUp();
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion0;
 
       EXPECT_CALL(*state_manager, createInitActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<InitActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::InitActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getInitActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<InitActorState>(cid));
+                                getCbor<InitActorState>(ipld, cid));
             auto s = std::make_shared<InitActorState>(current_state);
             return std::static_pointer_cast<states::InitActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v0/market/market_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/market/market_actor_test.cpp
@@ -51,7 +51,7 @@ namespace fc::vm::actor::builtin::v0::market {
   struct MarketActorTest : public MarketActorTestFixture<MarketActorState> {
     void SetUp() override {
       MarketActorTestFixture<MarketActorState>::SetUp();
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion0;
 
       addressCodeIdIs(miner_address, kStorageMinerCodeId);

--- a/test/core/vm/actor/builtin/v0/miner/miner_actor_v0_test.cpp
+++ b/test/core/vm/actor/builtin/v0/miner/miner_actor_v0_test.cpp
@@ -32,7 +32,7 @@ namespace fc::vm::actor::builtin::v0::miner {
       MinerActorTestFixture<MinerActorState>::SetUp();
       actorVersion = ActorVersion::kVersion0;
       anyCodeIdAddressIs(kAccountCodeId);
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
     }
 
     void expectEnrollCronEvent(ChainEpoch event_epoch,
@@ -142,11 +142,11 @@ namespace fc::vm::actor::builtin::v0::miner {
     EXPECT_EQ(state.proving_period_start, proving_period_start);
     EXPECT_EQ(state.current_deadline, 0);
 
-    EXPECT_OUTCOME_TRUE(deadlines, ipld->getCbor<Deadlines>(state.deadlines));
+    EXPECT_OUTCOME_TRUE(deadlines, state.deadlines.get());
     EXPECT_EQ(deadlines.due.size(), kWPoStPeriodDeadlines);
 
     for (const auto &deadline_cid : deadlines.due) {
-      EXPECT_OUTCOME_TRUE(deadline, ipld->getCbor<Deadline>(deadline_cid));
+      EXPECT_OUTCOME_TRUE(deadline, getCbor<Deadline>(ipld, deadline_cid));
       EXPECT_OUTCOME_EQ(deadline.partitions.size(), 0);
       EXPECT_OUTCOME_EQ(deadline.expirations_epochs.size(), 0);
       EXPECT_TRUE(deadline.post_submissions.empty());

--- a/test/core/vm/actor/builtin/v0/multisig_actor/multisig_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/multisig_actor/multisig_actor_test.cpp
@@ -82,9 +82,9 @@ namespace fc::vm::actor::builtin::v0::multisig {
       EXPECT_CALL(*state_manager, commitState(testing::_))
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state = std::static_pointer_cast<MultisigActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
             EXPECT_OUTCOME_TRUE(new_state,
-                                ipld->getCbor<MultisigActorState>(cid));
+                                getCbor<MultisigActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -92,15 +92,15 @@ namespace fc::vm::actor::builtin::v0::multisig {
       EXPECT_CALL(*state_manager, createMultisigActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<MultisigActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::MultisigActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getMultisigActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<MultisigActorState>(cid));
+                                getCbor<MultisigActorState>(ipld, cid));
             auto s = std::make_shared<MultisigActorState>(current_state);
             return std::static_pointer_cast<states::MultisigActorState>(s);
           }));
@@ -129,7 +129,7 @@ namespace fc::vm::actor::builtin::v0::multisig {
       state.start_epoch = 0;
       state.unlock_duration = 0;
 
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
     }
 
    protected:

--- a/test/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/payment_channel/payment_channel_actor_test.cpp
@@ -42,7 +42,7 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
 
   struct PaymentChannelActorTest : testing::Test {
     void SetUp() override {
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion0;
 
       EXPECT_CALL(runtime, getActorVersion())
@@ -78,9 +78,9 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state =
                 std::static_pointer_cast<PaymentChannelActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
             EXPECT_OUTCOME_TRUE(new_state,
-                                ipld->getCbor<PaymentChannelActorState>(cid));
+                                getCbor<PaymentChannelActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -88,16 +88,16 @@ namespace fc::vm::actor::builtin::v0::payment_channel {
       EXPECT_CALL(*state_manager, createPaymentChannelActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<PaymentChannelActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::PaymentChannelActorState>(
                 s);
           }));
 
       EXPECT_CALL(*state_manager, getPaymentChannelActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<PaymentChannelActorState>(cid));
+                                getCbor<PaymentChannelActorState>(ipld, cid));
             auto s = std::make_shared<PaymentChannelActorState>(current_state);
             return std::static_pointer_cast<states::PaymentChannelActorState>(
                 s);

--- a/test/core/vm/actor/builtin/v0/power/storage_power_actor_v0_test.cpp
+++ b/test/core/vm/actor/builtin/v0/power/storage_power_actor_v0_test.cpp
@@ -56,8 +56,8 @@ namespace fc::vm::actor::builtin::v0::storage_power {
       EXPECT_CALL(*state_manager, commitState(testing::_))
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state = std::static_pointer_cast<PowerActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
-            EXPECT_OUTCOME_TRUE(new_state, ipld->getCbor<PowerActorState>(cid));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
+            EXPECT_OUTCOME_TRUE(new_state, getCbor<PowerActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -65,15 +65,15 @@ namespace fc::vm::actor::builtin::v0::storage_power {
       EXPECT_CALL(*state_manager, createPowerActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<PowerActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::PowerActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getPowerActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<PowerActorState>(cid));
+                                getCbor<PowerActorState>(ipld, cid));
             auto s = std::make_shared<PowerActorState>(current_state);
             return std::static_pointer_cast<states::PowerActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v0/reward/reward_actor_v0_test.cpp
+++ b/test/core/vm/actor/builtin/v0/reward/reward_actor_v0_test.cpp
@@ -34,9 +34,9 @@ namespace fc::vm::actor::builtin::v0::reward {
 
       EXPECT_CALL(*state_manager, getRewardActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<RewardActorState>(cid));
+                                getCbor<RewardActorState>(ipld, cid));
             auto s = std::make_shared<RewardActorState>(current_state);
             return std::static_pointer_cast<states::RewardActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v0/verified_registry/verified_registry_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v0/verified_registry/verified_registry_actor_test.cpp
@@ -29,16 +29,16 @@ namespace fc::vm::actor::builtin::v0::verified_registry {
       EXPECT_CALL(*state_manager, createVerifiedRegistryActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<VerifiedRegistryActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::VerifiedRegistryActorState>(
                 s);
           }));
 
       EXPECT_CALL(*state_manager, getVerifiedRegistryActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<VerifiedRegistryActorState>(cid));
+                                getCbor<VerifiedRegistryActorState>(ipld, cid));
             auto s =
                 std::make_shared<VerifiedRegistryActorState>(current_state);
             return std::static_pointer_cast<states::VerifiedRegistryActorState>(
@@ -47,7 +47,7 @@ namespace fc::vm::actor::builtin::v0::verified_registry {
     }
 
     void setupState() {
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       state.root_key = root_key;
     }
 

--- a/test/core/vm/actor/builtin/v2/account/account_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/account/account_actor_test.cpp
@@ -28,9 +28,9 @@ namespace fc::vm::actor::builtin::v2::account {
 
       EXPECT_CALL(*state_manager, getAccountActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<AccountActorState>(cid));
+                                getCbor<AccountActorState>(ipld, cid));
             auto s = std::make_shared<AccountActorState>(current_state);
             return std::static_pointer_cast<states::AccountActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v2/cron/cron_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/cron/cron_actor_test.cpp
@@ -30,9 +30,9 @@ namespace fc::vm::actor::builtin::v2::cron {
 
       EXPECT_CALL(*state_manager, getCronActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<CronActorState>(cid));
+                                getCbor<CronActorState>(ipld, cid));
             auto s = std::make_shared<CronActorState>(current_state);
             return std::static_pointer_cast<states::CronActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v2/init/init_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/init/init_actor_test.cpp
@@ -25,21 +25,21 @@ namespace fc::vm::actor::builtin::v2::init {
   struct InitActorTest : public ActorTestFixture<InitActorState> {
     void SetUp() override {
       ActorTestFixture<InitActorState>::SetUp();
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion2;
 
       EXPECT_CALL(*state_manager, createInitActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<InitActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::InitActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getInitActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<InitActorState>(cid));
+                                getCbor<InitActorState>(ipld, cid));
             auto s = std::make_shared<InitActorState>(current_state);
             return std::static_pointer_cast<states::InitActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v2/market/market_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/market/market_actor_test.cpp
@@ -51,7 +51,7 @@ namespace fc::vm::actor::builtin::v2::market {
   struct MarketActorTest : public MarketActorTestFixture<MarketActorState> {
     void SetUp() override {
       MarketActorTestFixture<MarketActorState>::SetUp();
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion2;
 
       addressCodeIdIs(miner_address, kStorageMinerCodeId);

--- a/test/core/vm/actor/builtin/v2/miner/miner_actor_v2_test.cpp
+++ b/test/core/vm/actor/builtin/v2/miner/miner_actor_v2_test.cpp
@@ -31,7 +31,7 @@ namespace fc::vm::actor::builtin::v2::miner {
       MinerActorTestFixture<MinerActorState>::SetUp();
       actorVersion = ActorVersion::kVersion2;
       anyCodeIdAddressIs(kAccountCodeId);
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
     }
 
     /**
@@ -110,11 +110,11 @@ namespace fc::vm::actor::builtin::v2::miner {
     EXPECT_EQ(state.proving_period_start, proving_period_start);
     EXPECT_EQ(state.current_deadline, deadline_index);
 
-    EXPECT_OUTCOME_TRUE(deadlines, ipld->getCbor<Deadlines>(state.deadlines));
+    EXPECT_OUTCOME_TRUE(deadlines, state.deadlines.get());
     EXPECT_EQ(deadlines.due.size(), kWPoStPeriodDeadlines);
 
     for (const auto &deadline_cid : deadlines.due) {
-      EXPECT_OUTCOME_TRUE(deadline, ipld->getCbor<Deadline>(deadline_cid));
+      EXPECT_OUTCOME_TRUE(deadline, getCbor<Deadline>(ipld, deadline_cid));
       EXPECT_OUTCOME_EQ(deadline.partitions.size(), 0);
       EXPECT_OUTCOME_EQ(deadline.expirations_epochs.size(), 0);
       EXPECT_TRUE(deadline.post_submissions.empty());

--- a/test/core/vm/actor/builtin/v2/multisig_actor/multisig_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/multisig_actor/multisig_actor_test.cpp
@@ -84,9 +84,9 @@ namespace fc::vm::actor::builtin::v2::multisig {
       EXPECT_CALL(*state_manager, commitState(testing::_))
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state = std::static_pointer_cast<MultisigActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
             EXPECT_OUTCOME_TRUE(new_state,
-                                ipld->getCbor<MultisigActorState>(cid));
+                                getCbor<MultisigActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -94,15 +94,15 @@ namespace fc::vm::actor::builtin::v2::multisig {
       EXPECT_CALL(*state_manager, createMultisigActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<MultisigActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::MultisigActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getMultisigActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<MultisigActorState>(cid));
+                                getCbor<MultisigActorState>(ipld, cid));
             auto s = std::make_shared<MultisigActorState>(current_state);
             return std::static_pointer_cast<states::MultisigActorState>(s);
           }));
@@ -131,7 +131,7 @@ namespace fc::vm::actor::builtin::v2::multisig {
       state.start_epoch = 0;
       state.unlock_duration = 0;
 
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
     }
 
    protected:

--- a/test/core/vm/actor/builtin/v2/payment_channel/payment_channel_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/payment_channel/payment_channel_actor_test.cpp
@@ -42,7 +42,7 @@ namespace fc::vm::actor::builtin::v2::payment_channel {
 
   struct PaymentChannelActorTest : testing::Test {
     void SetUp() override {
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion2;
 
       EXPECT_CALL(runtime, getActorVersion())
@@ -78,9 +78,9 @@ namespace fc::vm::actor::builtin::v2::payment_channel {
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state =
                 std::static_pointer_cast<PaymentChannelActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
             EXPECT_OUTCOME_TRUE(new_state,
-                                ipld->getCbor<PaymentChannelActorState>(cid));
+                                getCbor<PaymentChannelActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -88,16 +88,16 @@ namespace fc::vm::actor::builtin::v2::payment_channel {
       EXPECT_CALL(*state_manager, createPaymentChannelActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<PaymentChannelActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::PaymentChannelActorState>(
                 s);
           }));
 
       EXPECT_CALL(*state_manager, getPaymentChannelActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<PaymentChannelActorState>(cid));
+                                getCbor<PaymentChannelActorState>(ipld, cid));
             auto s = std::make_shared<PaymentChannelActorState>(current_state);
             return std::static_pointer_cast<states::PaymentChannelActorState>(
                 s);

--- a/test/core/vm/actor/builtin/v2/power/storage_power_actor_v2_test.cpp
+++ b/test/core/vm/actor/builtin/v2/power/storage_power_actor_v2_test.cpp
@@ -54,8 +54,8 @@ namespace fc::vm::actor::builtin::v2::storage_power {
       EXPECT_CALL(*state_manager, commitState(testing::_))
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state = std::static_pointer_cast<PowerActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
-            EXPECT_OUTCOME_TRUE(new_state, ipld->getCbor<PowerActorState>(cid));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
+            EXPECT_OUTCOME_TRUE(new_state, getCbor<PowerActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -63,15 +63,15 @@ namespace fc::vm::actor::builtin::v2::storage_power {
       EXPECT_CALL(*state_manager, createPowerActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<PowerActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::PowerActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getPowerActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<PowerActorState>(cid));
+                                getCbor<PowerActorState>(ipld, cid));
             auto s = std::make_shared<PowerActorState>(current_state);
             return std::static_pointer_cast<states::PowerActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v2/reward/reward_actor_v2_test.cpp
+++ b/test/core/vm/actor/builtin/v2/reward/reward_actor_v2_test.cpp
@@ -36,9 +36,9 @@ namespace fc::vm::actor::builtin::v2::reward {
 
       EXPECT_CALL(*state_manager, getRewardActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<RewardActorState>(cid));
+                                getCbor<RewardActorState>(ipld, cid));
             auto s = std::make_shared<RewardActorState>(current_state);
             return std::static_pointer_cast<states::RewardActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v2/verified_registry/verified_registry_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v2/verified_registry/verified_registry_actor_test.cpp
@@ -30,16 +30,16 @@ namespace fc::vm::actor::builtin::v2::verified_registry {
       EXPECT_CALL(*state_manager, createVerifiedRegistryActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<VerifiedRegistryActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::VerifiedRegistryActorState>(
                 s);
           }));
 
       EXPECT_CALL(*state_manager, getVerifiedRegistryActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<VerifiedRegistryActorState>(cid));
+                                getCbor<VerifiedRegistryActorState>(ipld, cid));
             auto s =
                 std::make_shared<VerifiedRegistryActorState>(current_state);
             return std::static_pointer_cast<states::VerifiedRegistryActorState>(
@@ -48,7 +48,7 @@ namespace fc::vm::actor::builtin::v2::verified_registry {
     }
 
     void setupState() {
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       state.root_key = root_key;
     }
 

--- a/test/core/vm/actor/builtin/v3/account/account_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/account/account_actor_test.cpp
@@ -28,9 +28,9 @@ namespace fc::vm::actor::builtin::v3::account {
 
       EXPECT_CALL(*state_manager, getAccountActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<AccountActorState>(cid));
+                                getCbor<AccountActorState>(ipld, cid));
             auto s = std::make_shared<AccountActorState>(current_state);
             return std::static_pointer_cast<states::AccountActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v3/cron/cron_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/cron/cron_actor_test.cpp
@@ -30,9 +30,9 @@ namespace fc::vm::actor::builtin::v3::cron {
 
       EXPECT_CALL(*state_manager, getCronActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<CronActorState>(cid));
+                                getCbor<CronActorState>(ipld, cid));
             auto s = std::make_shared<CronActorState>(current_state);
             return std::static_pointer_cast<states::CronActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v3/init/init_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/init/init_actor_test.cpp
@@ -25,21 +25,21 @@ namespace fc::vm::actor::builtin::v3::init {
   struct InitActorTest : public ActorTestFixture<InitActorState> {
     void SetUp() override {
       ActorTestFixture<InitActorState>::SetUp();
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion3;
 
       EXPECT_CALL(*state_manager, createInitActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<InitActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::InitActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getInitActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<InitActorState>(cid));
+                                getCbor<InitActorState>(ipld, cid));
             auto s = std::make_shared<InitActorState>(current_state);
             return std::static_pointer_cast<states::InitActorState>(s);
           }));

--- a/test/core/vm/actor/builtin/v3/multisig_actor/multisig_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/multisig_actor/multisig_actor_test.cpp
@@ -84,9 +84,9 @@ namespace fc::vm::actor::builtin::v3::multisig {
       EXPECT_CALL(*state_manager, commitState(testing::_))
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state = std::static_pointer_cast<MultisigActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
             EXPECT_OUTCOME_TRUE(new_state,
-                                ipld->getCbor<MultisigActorState>(cid));
+                                getCbor<MultisigActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -94,15 +94,15 @@ namespace fc::vm::actor::builtin::v3::multisig {
       EXPECT_CALL(*state_manager, createMultisigActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<MultisigActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::MultisigActorState>(s);
           }));
 
       EXPECT_CALL(*state_manager, getMultisigActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<MultisigActorState>(cid));
+                                getCbor<MultisigActorState>(ipld, cid));
             auto s = std::make_shared<MultisigActorState>(current_state);
             return std::static_pointer_cast<states::MultisigActorState>(s);
           }));
@@ -131,7 +131,7 @@ namespace fc::vm::actor::builtin::v3::multisig {
       state.start_epoch = 0;
       state.unlock_duration = 0;
 
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
     }
 
    protected:

--- a/test/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/payment_channel/payment_channel_actor_test.cpp
@@ -42,7 +42,7 @@ namespace fc::vm::actor::builtin::v3::payment_channel {
 
   struct PaymentChannelActorTest : testing::Test {
     void SetUp() override {
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       actorVersion = ActorVersion::kVersion3;
 
       EXPECT_CALL(runtime, getActorVersion())
@@ -78,9 +78,9 @@ namespace fc::vm::actor::builtin::v3::payment_channel {
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state =
                 std::static_pointer_cast<PaymentChannelActorState>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
             EXPECT_OUTCOME_TRUE(new_state,
-                                ipld->getCbor<PaymentChannelActorState>(cid));
+                                getCbor<PaymentChannelActorState>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));
@@ -88,16 +88,16 @@ namespace fc::vm::actor::builtin::v3::payment_channel {
       EXPECT_CALL(*state_manager, createPaymentChannelActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<PaymentChannelActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::PaymentChannelActorState>(
                 s);
           }));
 
       EXPECT_CALL(*state_manager, getPaymentChannelActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<PaymentChannelActorState>(cid));
+                                getCbor<PaymentChannelActorState>(ipld, cid));
             auto s = std::make_shared<PaymentChannelActorState>(current_state);
             return std::static_pointer_cast<states::PaymentChannelActorState>(
                 s);

--- a/test/core/vm/actor/builtin/v3/verified_registry/verified_registry_actor_test.cpp
+++ b/test/core/vm/actor/builtin/v3/verified_registry/verified_registry_actor_test.cpp
@@ -29,16 +29,16 @@ namespace fc::vm::actor::builtin::v3::verified_registry {
       EXPECT_CALL(*state_manager, createVerifiedRegistryActorState(testing::_))
           .WillRepeatedly(testing::Invoke([&](auto) {
             auto s = std::make_shared<VerifiedRegistryActorState>();
-            ipld->load(*s);
+            cbor_blake::cbLoadT(ipld, *s);
             return std::static_pointer_cast<states::VerifiedRegistryActorState>(
                 s);
           }));
 
       EXPECT_CALL(*state_manager, getVerifiedRegistryActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
             EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->getCbor<VerifiedRegistryActorState>(cid));
+                                getCbor<VerifiedRegistryActorState>(ipld, cid));
             auto s =
                 std::make_shared<VerifiedRegistryActorState>(current_state);
             return std::static_pointer_cast<states::VerifiedRegistryActorState>(
@@ -47,7 +47,7 @@ namespace fc::vm::actor::builtin::v3::verified_registry {
     }
 
     void setupState() {
-      ipld->load(state);
+      cbor_blake::cbLoadT(ipld, state);
       state.root_key = root_key;
     }
 

--- a/test/core/vm/state/state_tree_test.cpp
+++ b/test/core/vm/state/state_tree_test.cpp
@@ -85,7 +85,7 @@ TEST_F(StateTreeTest, RegisterNewAddressLookupId) {
 TEST_F(StateTreeTest, Walk) {
   using namespace fc;
   adt::Map<vm::actor::Actor, adt::AddressKeyer> map{store_};
-  auto head1{store_->setCbor(3).value()};
+  auto head1{setCbor(store_, 3).value()};
   auto code1{vm::actor::code::init0};
   map.set(Address::makeFromId(1), {code1, head1}).value();
   codec::cbor::light_reader::HamtWalk walk{

--- a/test/testutil/init_actor.hpp
+++ b/test/testutil/init_actor.hpp
@@ -26,7 +26,7 @@ std::shared_ptr<fc::vm::state::StateTree> setupInitActor(
   init_state.address_map = {store, 0, false};
   init_state.next_id = next_id;
   init_state.network_name = "n";
-  EXPECT_OUTCOME_TRUE(head, store->setCbor(init_state));
+  EXPECT_OUTCOME_TRUE(head, fc::setCbor(store, init_state));
   EXPECT_OUTCOME_TRUE_1(state_tree->set(fc::vm::actor::kInitAddress,
                                         {vm::actor::code::init0, head, 0, 0}));
   return state_tree;

--- a/test/testutil/vm/actor/builtin/actor_test_fixture.hpp
+++ b/test/testutil/vm/actor/builtin/actor_test_fixture.hpp
@@ -75,8 +75,8 @@ namespace fc::testutil::vm::actor::builtin {
       EXPECT_CALL(*state_manager, commitState(testing::_))
           .WillRepeatedly(testing::Invoke([&](const auto &s) {
             auto temp_state = std::static_pointer_cast<State>(s);
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(*temp_state));
-            EXPECT_OUTCOME_TRUE(new_state, ipld->getCbor<State>(cid));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, *temp_state));
+            EXPECT_OUTCOME_TRUE(new_state, getCbor<State>(ipld, cid));
             state = std::move(new_state);
             return outcome::success();
           }));

--- a/test/testutil/vm/actor/builtin/market/market_actor_test_fixture.hpp
+++ b/test/testutil/vm/actor/builtin/market/market_actor_test_fixture.hpp
@@ -55,16 +55,15 @@ namespace fc::testutil::vm::actor::builtin::market {
 
       EXPECT_CALL(*state_manager, getMarketActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
-            EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->template getCbor<State>(cid));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
+            EXPECT_OUTCOME_TRUE(current_state, getCbor<State>(ipld, cid));
             auto s = std::make_shared<State>(current_state);
             return std::static_pointer_cast<BaseMarketActorState>(s);
           }));
     }
 
     void loadState(State &s) {
-      ipld->load(s);
+      cbor_blake::cbLoadT(ipld, s);
     }
 
     void expectSendFunds(const Address &address, TokenAmount amount) {

--- a/test/testutil/vm/actor/builtin/miner/miner_actor_test_fixture.hpp
+++ b/test/testutil/vm/actor/builtin/miner/miner_actor_test_fixture.hpp
@@ -38,16 +38,15 @@ namespace fc::testutil::vm::actor::builtin::miner {
 
       EXPECT_CALL(*state_manager, getMinerActorState())
           .WillRepeatedly(testing::Invoke([&]() {
-            EXPECT_OUTCOME_TRUE(cid, ipld->setCbor(state));
-            EXPECT_OUTCOME_TRUE(current_state,
-                                ipld->template getCbor<State>(cid));
+            EXPECT_OUTCOME_TRUE(cid, setCbor(ipld, state));
+            EXPECT_OUTCOME_TRUE(current_state, getCbor<State>(ipld, cid));
             auto s = std::make_shared<State>(current_state);
             return std::static_pointer_cast<BaseMinerActorState>(s);
           }));
     }
 
     void loadState(State &s) {
-      ipld->load(s);
+      cbor_blake::cbLoadT(ipld, s);
     }
 
     void initEmptyState() {


### PR DESCRIPTION
`getCbor` as member of `Ipld` can't see `shared_ptr` (`this` is raw pointer).
`getCbor` should be separated from `Ipld` interface.
`getCbor` should work with `CbIpld`.

`ACTOR_STATE_TO_CBOR_THIS` macro to implement `State::toCbor`.

fix `CborDecodeStream` last token was not cleared.