### PR TITLE
fix CborSteam - now class maintains the lifetime of buffer ot be write

### DIFF
--- a/core/common/libp2p/cbor_stream.hpp
+++ b/core/common/libp2p/cbor_stream.hpp
@@ -51,7 +51,8 @@ namespace fc::common::libp2p {
       if (!encoded) {
         return cb(encoded.error());
       }
-      writeRaw(encoded.value(), std::move(cb));
+      encoded_ = std::move(encoded.value());
+      writeRaw(encoded_, std::move(cb));
     }
 
     void close() {
@@ -62,6 +63,11 @@ namespace fc::common::libp2p {
     void readMore(ReadCallbackFunc cb);
     void consume(gsl::span<uint8_t> input, ReadCallbackFunc cb);
 
+    /**
+     * Persistent buffer of data to be written to the libp2p stream to maintain
+     * data validity until the callback is executed
+     */
+    Buffer encoded_;
     std::shared_ptr<Stream> stream_;
     CborBuffering buffering_;
     std::vector<uint8_t> buffer_;


### PR DESCRIPTION
Signed-off-by: Alexey-N-Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
From libp2p
```
     * @note caller should maintain validity of an input buffer until callback
     * is executed. It is usually done with either wrapping buffer as shared
     * pointer, or having buffer as part of some class/struct, and using
     * enable_shared_from_this()
```
### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
