### PR TITLE
update onDealSectorCommitted

### DIFF
--- a/core/markets/storage/chain_events/CMakeLists.txt
+++ b/core/markets/storage/chain_events/CMakeLists.txt
@@ -8,4 +8,5 @@ add_library(chain_events
     )
 target_link_libraries(chain_events
     api
+    api_ipfs_datastore
     )

--- a/core/markets/storage/chain_events/chain_events.hpp
+++ b/core/markets/storage/chain_events/chain_events.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <future>
 #include "storage/mpool/mpool.hpp"
 
 namespace fc::markets::storage::chain_events {
@@ -19,14 +18,7 @@ namespace fc::markets::storage::chain_events {
    */
   class ChainEvents {
    public:
-    using Cb = std::function<void(void)>;
-
-    struct EventWatch {
-      Address provider;
-      DealId deal_id;
-      boost::optional<SectorNumber> sector_number;
-      Cb cb;
-    };
+    using CommitCb = std::function<void(outcome::result<void>)>;
 
     virtual ~ChainEvents() = default;
 
@@ -39,6 +31,6 @@ namespace fc::markets::storage::chain_events {
      */
     virtual void onDealSectorCommitted(const Address &provider,
                                        const DealId &deal_id,
-                                       Cb cb) = 0;
+                                       CommitCb cb) = 0;
   };
 }  // namespace fc::markets::storage::chain_events

--- a/core/markets/storage/chain_events/impl/chain_events_impl.cpp
+++ b/core/markets/storage/chain_events/impl/chain_events_impl.cpp
@@ -4,13 +4,21 @@
  */
 
 #include "markets/storage/chain_events/impl/chain_events_impl.hpp"
-#include "vm/actor/builtin/v0/miner/miner_actor.hpp"
+#include "common/outcome_fmt.hpp"
+#include "storage/ipfs/api_ipfs_datastore/api_ipfs_datastore.hpp"
+#include "vm/actor/builtin/states/miner/miner_actor_state.hpp"
+#include "vm/actor/builtin/v5/miner/miner_actor.hpp"
+#include "vm/toolchain/toolchain.hpp"
 
 namespace fc::markets::storage::chain_events {
+  using primitives::RleBitset;
   using primitives::tipset::HeadChangeType;
+  using vm::VMExitCode;
   using vm::actor::builtin::types::miner::SectorPreCommitInfo;
-  using vm::actor::builtin::v0::miner::PreCommitSector;
-  using vm::actor::builtin::v0::miner::ProveCommitSector;
+  using vm::actor::builtin::v5::miner::PreCommitBatch;
+  using vm::actor::builtin::v5::miner::PreCommitSector;
+  using vm::actor::builtin::v5::miner::ProveCommitAggregate;
+  using vm::actor::builtin::v5::miner::ProveCommitSector;
   using vm::message::SignedMessage;
 
   ChainEventsImpl::ChainEventsImpl(std::shared_ptr<FullNodeApi> api)
@@ -30,12 +38,45 @@ namespace fc::markets::storage::chain_events {
 
   void ChainEventsImpl::onDealSectorCommitted(const Address &provider,
                                               const DealId &deal_id,
-                                              Cb cb) {
-    std::unique_lock lock(watched_events_mutex_);
-    watched_events_.emplace_back(EventWatch{.provider = provider,
-                                            .deal_id = deal_id,
-                                            .sector_number = boost::none,
-                                            .cb = std::move(cb)});
+                                              CommitCb cb) {
+    constexpr auto kStop{std::errc::interrupted};
+    const auto _r{[&]() -> outcome::result<void> {
+      OUTCOME_TRY(deal, api_->StateMarketStorageDeal(deal_id, head_->key));
+      if (deal.state.sector_start_epoch > 0) {
+        cb(outcome::success());
+        return outcome::success();
+      }
+      OUTCOME_TRY(actor, api_->StateGetActor(provider, head_->key));
+      const auto ipld{
+          std::make_shared<fc::storage::ipfs::ApiIpfsDatastore>(api_)};
+      OUTCOME_TRY(network, api_->StateNetworkVersion(head_->key));
+      ipld->actor_version =
+          vm::toolchain::Toolchain::getActorVersionForNetwork(network);
+      OUTCOME_TRY(state,
+                  getCbor<vm::actor::builtin::states::MinerActorStatePtr>(
+                      ipld, actor.head));
+      OUTCOME_TRY(state->precommitted_sectors.visit(
+          [&](auto sector, auto &precommit) -> outcome::result<void> {
+            const auto &ids{precommit.info.deal_ids};
+            if (std::find(ids.begin(), ids.end(), deal_id) != ids.end()) {
+              std::unique_lock lock{watched_events_mutex_};
+              watched_events_[provider].commits.emplace(sector, std::move(cb));
+              return outcome::failure(kStop);
+            }
+            return outcome::success();
+          }));
+      std::unique_lock lock{watched_events_mutex_};
+      watched_events_[provider].precommits.emplace(
+          deal_id, [this, provider, cb{std::move(cb)}](auto _sector) {
+            OUTCOME_CB(auto sector, _sector);
+            std::unique_lock lock{watched_events_mutex_};
+            watched_events_[provider].commits.emplace(sector, std::move(cb));
+          });
+      return outcome::success();
+    }()};
+    if (!_r && _r.error() != kStop) {
+      logger_->warn("ChainEventsImpl::onDealSectorCommitted {:#}", _r.error());
+    }
   }
 
   /**
@@ -46,8 +87,12 @@ namespace fc::markets::storage::chain_events {
    */
   bool ChainEventsImpl::onRead(
       const boost::optional<std::vector<HeadChange>> &changes) {
+    std::unique_lock lock{watched_events_mutex_};
     if (changes) {
       for (const auto &change : changes.get()) {
+        if (change.type != HeadChangeType::REVERT) {
+          head_ = change.value;
+        }
         if (change.type == HeadChangeType::APPLY) {
           for (auto &block_cid : change.value->key.cids()) {
             auto block_messages = api_->ChainGetBlockMessages(CID{block_cid});
@@ -75,65 +120,78 @@ namespace fc::markets::storage::chain_events {
         }
       }
     }
+    lock.unlock();
     return true;
   };
 
   outcome::result<void> ChainEventsImpl::onMessage(
       const UnsignedMessage &message, const CID &cid) {
-    std::vector<EventWatch>::iterator watch_it;
-    boost::optional<SectorNumber> update_sector_number;
-    bool prove_sector_committed = false;
-    {
-      std::shared_lock lock(watched_events_mutex_);
-      for (watch_it = watched_events_.begin();
-           watch_it != watched_events_.end();
-           ++watch_it) {
-        if (message.to == watch_it->provider) {
-          if (message.method == PreCommitSector::Number) {
-            OUTCOME_TRY(
-                pre_commit_info,
-                codec::cbor::decode<SectorPreCommitInfo>(message.params));
-            auto deal_ids = pre_commit_info.deal_ids;
-            // save sector number if deal id matches and it is not saved yet
-            if (std::find(deal_ids.begin(), deal_ids.end(), watch_it->deal_id)
-                    != deal_ids.end()
-                && !watch_it->sector_number) {
-              update_sector_number = pre_commit_info.sector;
-              break;
-            }
-          } else if (message.method == ProveCommitSector::Number) {
-            OUTCOME_TRY(
-                prove_commit_params,
-                codec::cbor::decode<ProveCommitSector::Params>(message.params));
-            // notify if sector number matches,
-            if (watch_it->sector_number
-                && prove_commit_params.sector == watch_it->sector_number) {
-              prove_sector_committed = true;
-              break;
-            }
-          }
+    const auto _watch{watched_events_.find(message.to)};
+    if (_watch == watched_events_.end()) {
+      return outcome::success();
+    }
+    auto &watch{_watch->second};
+    const auto on_precommit{[&](const SectorPreCommitInfo &precommit) {
+      for (auto &deal_id : precommit.deal_ids) {
+        const auto [begin, end]{watch.precommits.equal_range(deal_id)};
+        auto it{begin};
+        while (it != end) {
+          api_->StateWaitMsg(
+              [cb{std::move(it->second)}, sector{precommit.sector}](auto _r) {
+                OUTCOME_CB(auto r, _r);
+                if (r.receipt.exit_code != VMExitCode::kOk) {
+                  return cb(r.receipt.exit_code);
+                }
+                return cb(sector);
+              },
+              cid,
+              kMessageConfidence,
+              api::kLookbackNoLimit,
+              true);
+          it = watch.precommits.erase(it);
         }
       }
-    }
-
-    if (watch_it != watched_events_.end()) {
-      std::unique_lock lock(watched_events_mutex_);
-      if (update_sector_number) {
-        watch_it->sector_number = update_sector_number;
-      }
-
-      if (prove_sector_committed) {
+    }};
+    const auto on_commit{[&](SectorNumber sector) {
+      const auto [begin, end]{watch.commits.equal_range(sector)};
+      auto it{begin};
+      while (it != end) {
         api_->StateWaitMsg(
-            [cb{std::move(watch_it->cb)}](auto _r) {
-              if (_r) {
-                cb();
+            [cb{std::move(it->second)}](auto _r) {
+              OUTCOME_CB(auto r, _r);
+              if (r.receipt.exit_code != vm::VMExitCode::kOk) {
+                return cb(r.receipt.exit_code);
               }
+              return cb(outcome::success());
             },
             cid,
             kMessageConfidence,
             api::kLookbackNoLimit,
             true);
-        watched_events_.erase(watch_it);
+        it = watch.commits.erase(it);
+      }
+    }};
+    if (message.method == PreCommitSector::Number) {
+      OUTCOME_TRY(param,
+                  codec::cbor::decode<PreCommitSector::Params>(message.params));
+      on_precommit(param);
+    } else if (message.method == PreCommitBatch::Number) {
+      OUTCOME_TRY(param,
+                  codec::cbor::decode<PreCommitBatch::Params>(message.params));
+      for (const auto &precommit : param.sectors) {
+        on_precommit(precommit);
+      }
+    } else if (message.method == ProveCommitSector::Number) {
+      OUTCOME_TRY(
+          param,
+          codec::cbor::decode<ProveCommitSector::Params>(message.params));
+      on_commit(param.sector);
+    } else if (message.method == ProveCommitAggregate::Number) {
+      OUTCOME_TRY(
+          param,
+          codec::cbor::decode<ProveCommitAggregate::Params>(message.params));
+      for (auto &sector : param.sectors) {
+        on_commit(sector);
       }
     }
     return outcome::success();

--- a/core/markets/storage/client/impl/storage_market_client_impl.cpp
+++ b/core/markets/storage/client/impl/storage_market_client_impl.cpp
@@ -729,7 +729,8 @@ namespace fc::markets::storage::client {
     chain_events_->onDealSectorCommitted(
         deal->client_deal_proposal.proposal.provider,
         deal->deal_id,
-        [self{shared_from_this()}, deal] {
+        [self{shared_from_this()}, deal](auto _r) {
+          SELF_FSM_HALT_ON_ERROR(_r, "onDealSectorCommitted error", deal);
           OUTCOME_EXCEPT(self->fsm_->send(
               deal, ClientEvent::ClientEventDealActivated, {}));
         });

--- a/core/markets/storage/provider/impl/provider_impl.cpp
+++ b/core/markets/storage/provider/impl/provider_impl.cpp
@@ -637,7 +637,7 @@ namespace fc::markets::storage::provider {
       ProviderEvent event,
       StorageDealStatus from,
       StorageDealStatus to) {
-     api_->StateWaitMsg(
+    api_->StateWaitMsg(
         [self{shared_from_this()}, deal, to](outcome::result<MsgWait> result) {
           SELF_FSM_HALT_ON_ERROR(
               result, "Publish storage deal message error", deal);
@@ -691,7 +691,10 @@ namespace fc::markets::storage::provider {
       StorageDealStatus from,
       StorageDealStatus to) {
     chain_events_->onDealSectorCommitted(
-        deal->client_deal_proposal.proposal.provider, deal->deal_id, [=] {
+        deal->client_deal_proposal.proposal.provider,
+        deal->deal_id,
+        [=](auto _r) {
+          FSM_HALT_ON_ERROR(_r, "onDealSectorCommitted error", deal);
           FSM_SEND(deal, ProviderEvent::ProviderEventDealActivated);
         });
   }

--- a/core/miner/storage_fsm/deal_info_manager.hpp
+++ b/core/miner/storage_fsm/deal_info_manager.hpp
@@ -18,7 +18,7 @@ namespace fc::mining {
 
   struct CurrentDealInfo {
     DealId deal_id;
-    boost::optional<StorageDeal> market_deal;
+    StorageDeal market_deal;
     TipsetKey publish_msg_tipset;
   };
 

--- a/core/vm/actor/builtin/states/miner/miner_actor_state.hpp
+++ b/core/vm/actor/builtin/states/miner/miner_actor_state.hpp
@@ -325,6 +325,6 @@ namespace fc::vm::actor::builtin::states {
   using MinerActorStatePtr = Universal<MinerActorState>;
 
   outcome::result<MinerActorStatePtr> makeEmptyMinerState(
-      const Runtime &runtime);
+      const IpldPtr &runtime);
 
 }  // namespace fc::vm::actor::builtin::states

--- a/core/vm/actor/builtin/types/miner/deadline.cpp
+++ b/core/vm/actor/builtin/types/miner/deadline.cpp
@@ -357,14 +357,11 @@ namespace fc::vm::actor::builtin::types::miner {
   }
 
   outcome::result<Universal<Deadline>> makeEmptyDeadline(
-      const Runtime &runtime, const CID &empty_amt_cid) {
-    const auto version = runtime.getActorVersion();
-    const auto ipld = runtime.getIpfsDatastore();
-
-    Universal<Deadline> deadline{version};
+      const IpldPtr &ipld, const CID &empty_amt_cid) {
+    Universal<Deadline> deadline{ipld->actor_version};
     cbor_blake::cbLoadT(ipld, deadline);
 
-    if (version < ActorVersion::kVersion3) {
+    if (ipld->actor_version < ActorVersion::kVersion3) {
       deadline->partitions = {empty_amt_cid, ipld};
       deadline->expirations_epochs = {empty_amt_cid, ipld};
     } else {

--- a/core/vm/actor/builtin/types/miner/deadline.hpp
+++ b/core/vm/actor/builtin/types/miner/deadline.hpp
@@ -170,6 +170,6 @@ namespace fc::vm::actor::builtin::types::miner {
   };
 
   outcome::result<Universal<Deadline>> makeEmptyDeadline(
-      const Runtime &runtime, const CID &empty_amt_cid);
+      const IpldPtr &ipld, const CID &empty_amt_cid);
 
 }  // namespace fc::vm::actor::builtin::types::miner

--- a/core/vm/actor/builtin/types/miner/deadlines.cpp
+++ b/core/vm/actor/builtin/types/miner/deadlines.cpp
@@ -70,10 +70,10 @@ namespace fc::vm::actor::builtin::types::miner {
     return std::make_tuple(dl_id, part_id);
   }
 
-  outcome::result<Deadlines> makeEmptyDeadlines(const Runtime &runtime,
+  outcome::result<Deadlines> makeEmptyDeadlines(const IpldPtr &ipld,
                                                 const CID &empty_amt_cid) {
-    OUTCOME_TRY(deadline, makeEmptyDeadline(runtime, empty_amt_cid));
-    OUTCOME_TRY(deadline_cid, setCbor(runtime.getIpfsDatastore(), deadline));
+    OUTCOME_TRY(deadline, makeEmptyDeadline(ipld, empty_amt_cid));
+    OUTCOME_TRY(deadline_cid, setCbor(ipld, deadline));
     adt::CbCidT<Universal<Deadline>> deadline_cid_t{deadline_cid};
     return Deadlines{std::vector(kWPoStPeriodDeadlines, deadline_cid_t)};
   }

--- a/core/vm/actor/builtin/types/miner/deadlines.hpp
+++ b/core/vm/actor/builtin/types/miner/deadlines.hpp
@@ -36,7 +36,7 @@ namespace fc::vm::actor::builtin::types::miner {
   };
   CBOR_TUPLE(Deadlines, due)
 
-  outcome::result<Deadlines> makeEmptyDeadlines(const Runtime &runtime,
+  outcome::result<Deadlines> makeEmptyDeadlines(const IpldPtr &ipld,
                                                 const CID &empty_amt_cid);
 
 }  // namespace fc::vm::actor::builtin::types::miner

--- a/core/vm/actor/builtin/v5/miner/miner_actor.hpp
+++ b/core/vm/actor/builtin/v5/miner/miner_actor.hpp
@@ -10,6 +10,7 @@
 #include "vm/actor/builtin/types/miner/sector_info.hpp"
 
 namespace fc::vm::actor::builtin::v5::miner {
+  using primitives::RleBitset;
   using types::miner::SectorPreCommitInfo;
 
   // TODO implement
@@ -50,6 +51,15 @@ namespace fc::vm::actor::builtin::v5::miner {
     ACTOR_METHOD_DECL();
   };
   CBOR_TUPLE(PreCommitBatch::Params, sectors);
+
+  struct ProveCommitAggregate : ActorMethodBase<26> {
+    struct Params {
+      RleBitset sectors;
+      Bytes proof;
+    };
+    ACTOR_METHOD_DECL();
+  };
+  CBOR_TUPLE(ProveCommitAggregate::Params, sectors, proof);
 
   // extern const ActorExports exports;
 

--- a/test/core/markets/storage/chain_events/CMakeLists.txt
+++ b/test/core/markets/storage/chain_events/CMakeLists.txt
@@ -8,4 +8,5 @@ addtest(chain_events_test
     )
 target_link_libraries(chain_events_test
     chain_events
+    ipfs_datastore_in_memory
     )

--- a/test/core/markets/storage/chain_events/chain_events_test.cpp
+++ b/test/core/markets/storage/chain_events/chain_events_test.cpp
@@ -4,11 +4,14 @@
  */
 
 #include <gtest/gtest.h>
+
 #include "markets/storage/chain_events/impl/chain_events_impl.hpp"
 #include "storage/ipfs/impl/in_memory_datastore.hpp"
 #include "testutil/literals.hpp"
+#include "testutil/mocks/api.hpp"
 #include "testutil/outcome.hpp"
-#include "vm/actor/builtin/v0/miner/miner_actor.hpp"
+#include "vm/actor/builtin/states/miner/miner_actor_state.hpp"
+#include "vm/actor/builtin/v5/miner/miner_actor.hpp"
 
 namespace fc::markets::storage::chain_events {
   using adt::Channel;
@@ -21,21 +24,77 @@ namespace fc::markets::storage::chain_events {
   using primitives::tipset::HeadChange;
   using primitives::tipset::HeadChangeType;
   using primitives::tipset::Tipset;
+  using testing::_;
   using vm::actor::MethodParams;
   using vm::actor::builtin::v0::miner::PreCommitSector;
   using vm::actor::builtin::v0::miner::ProveCommitSector;
   using vm::actor::builtin::v0::miner::SectorPreCommitInfo;
   using vm::message::SignedMessage;
   using vm::message::UnsignedMessage;
+  using vm::version::NetworkVersion;
+
+  const outcome::result<void> void_success{outcome::success()};
+  const auto cid0{"010001020001"_cid};
 
   class ChainEventsTest : public ::testing::Test {
    public:
+    NetworkVersion network_version{NetworkVersion::kVersion13};
+    std::shared_ptr<InMemoryDatastore> ipld{
+        std::make_shared<InMemoryDatastore>()};
     Address provider = Address::makeFromId(1);
     DealId deal_id{1};
     SectorNumber sector_number{13};
     std::shared_ptr<FullNodeApi> api{std::make_shared<FullNodeApi>()};
     std::shared_ptr<ChainEventsImpl> events{
         std::make_shared<ChainEventsImpl>(api)};
+    Chan<std::vector<HeadChange>> head_chan{
+        std::make_shared<Channel<std::vector<HeadChange>>>()};
+    CbCid block0{CbCid::hash("00"_unhex)};
+    CbCid block1{CbCid::hash("01"_unhex)};
+    CbCid block2{CbCid::hash("02"_unhex)};
+
+    MOCK_API(api, ChainGetBlockMessages);
+    MOCK_API(api, ChainNotify);
+    MOCK_API(api, StateGetActor);
+    MOCK_API(api, StateMarketStorageDeal);
+    MOCK_API(api, StateNetworkVersion);
+    MOCK_API_CB(api, StateWaitMsg);
+
+    using MockCb = testing::MockFunction<void(outcome::result<void>)>;
+
+    void chainNotify(HeadChangeType type, CbCid block) {
+      const auto ts{std::make_shared<Tipset>()};
+      ts->key = {{block}};
+      head_chan.channel->write({{type, ts}});
+    }
+
+    template <typename F>
+    void withPrecommits(const CbCid &block, const F &f) {
+      TipsetKey tsk{{block}};
+      ipld->actor_version = actorVersion(network_version);
+      auto state{vm::actor::builtin::states::makeEmptyMinerState(ipld).value()};
+      state->miner_info.cid = cid0;
+      state->vesting_funds.cid = cid0;
+      f([&](SectorNumber sector, std::vector<DealId> deal_ids) {
+        vm::actor::builtin::types::miner::SectorPreCommitOnChainInfo info;
+        info.info.deal_ids = std::move(deal_ids);
+        state->precommitted_sectors.set(sector, info).value();
+      });
+      vm::actor::Actor actor;
+      actor.head = setCbor(ipld, state).value();
+      EXPECT_CALL(mock_StateGetActor, Call(provider, tsk))
+          .WillRepeatedly(testing::Return(actor));
+      EXPECT_CALL(mock_StateNetworkVersion, Call(tsk))
+          .WillRepeatedly(testing::Return(network_version));
+    }
+
+    void SetUp() override {
+      api->ChainReadObj = [this](const CID &cid) { return ipld->get(cid); };
+      EXPECT_CALL(mock_ChainNotify, Call())
+          .WillOnce(testing::Return(head_chan));
+      EXPECT_OUTCOME_TRUE_1(events->init());
+      chainNotify(HeadChangeType::CURRENT, block0);
+    }
   };
 
   /**
@@ -44,60 +103,51 @@ namespace fc::markets::storage::chain_events {
    * @then event is triggered
    */
   TEST_F(ChainEventsTest, CommitSector) {
-    const auto block_cid{CbCid::hash("01"_unhex)};
-
-    api->ChainGetBlockMessages = {[block_cid, this](const CID &cid)
-                                      -> outcome::result<BlockMessages> {
-      // PreCommitSector message call
-      SectorPreCommitInfo pre_commit_info;
-      pre_commit_info.sealed_cid = "010001020001"_cid;
-      pre_commit_info.deal_ids.emplace_back(deal_id);
-      pre_commit_info.sector = sector_number;
-      EXPECT_OUTCOME_TRUE(pre_commit_params,
-                          codec::cbor::encode(pre_commit_info));
-      UnsignedMessage pre_commit_message;
-      pre_commit_message.to = provider;
-      pre_commit_message.method = PreCommitSector::Number;
-      pre_commit_message.params = MethodParams{pre_commit_params};
-
-      // ProveCommitSector message call
-      ProveCommitSector::Params prove_commit_param;
-      prove_commit_param.sector = sector_number;
-      EXPECT_OUTCOME_TRUE(encoded_prove_commit_params,
-                          codec::cbor::encode(prove_commit_param));
-      UnsignedMessage prove_commit_message;
-      prove_commit_message.to = provider;
-      prove_commit_message.method = ProveCommitSector::Number;
-      prove_commit_message.params = MethodParams{encoded_prove_commit_params};
-
-      if (asBlake(cid) != block_cid) throw "wrong block requested";
-      return BlockMessages{.bls = {pre_commit_message, prove_commit_message}};
+    boost::asio::io_context io;
+    const auto io_StateWaitMsg{
+        testing::Invoke([&](auto cb, auto, auto, auto, auto) {
+          io.post([cb{std::move(cb)}] { cb(outcome::success()); });
+        })};
+    const auto io_run_one{[&] {
+      io.restart();
+      io.run_one();
     }};
 
-    api->ChainNotify = {
-        [block_cid]() -> outcome::result<Chan<std::vector<HeadChange>>> {
-          auto channel{std::make_shared<Channel<std::vector<HeadChange>>>()};
+    EXPECT_CALL(mock_StateMarketStorageDeal, Call(_, _))
+        .WillOnce(testing::Return(api::StorageDeal{}));
+    withPrecommits(block0, [](auto) {});
+    MockCb cb;
+    events->onDealSectorCommitted(provider, deal_id, cb.AsStdFunction());
 
-          auto tipset = std::make_shared<Tipset>();
-          tipset->key = TipsetKey{{block_cid}};
-          HeadChange change{.type = HeadChangeType::APPLY, .value = tipset};
-          channel->write({change});
+    SectorPreCommitInfo pre_commit_info;
+    pre_commit_info.sealed_cid = cid0;
+    pre_commit_info.deal_ids.emplace_back(deal_id);
+    pre_commit_info.sector = sector_number;
+    UnsignedMessage pre_commit_message;
+    pre_commit_message.to = provider;
+    pre_commit_message.method = PreCommitSector::Number;
+    pre_commit_message.params = codec::cbor::encode(pre_commit_info).value();
+    EXPECT_CALL(mock_ChainGetBlockMessages, Call(CID{block1}))
+        .WillOnce(testing::Return(BlockMessages{{pre_commit_message}, {}, {}}));
+    EXPECT_CALL(mock_StateWaitMsg, Call(_, _, _, _, _))
+        .WillOnce(io_StateWaitMsg);
+    chainNotify(HeadChangeType::APPLY, block1);
+    io_run_one();
 
-          return Chan{std::move(channel)};
-        }};
-
-    api->StateWaitMsg =
-        [](auto &, auto, auto, auto) -> outcome::result<api::MsgWait> {
-      return outcome::success();
-    };
-
-    bool is_called = false;
-    events->onDealSectorCommitted(
-        provider, deal_id, [&]() { is_called = true; });
-
-    EXPECT_OUTCOME_TRUE_1(events->init());
-
-    EXPECT_TRUE(is_called);
+    UnsignedMessage prove_commit_message;
+    prove_commit_message.to = provider;
+    prove_commit_message.method = ProveCommitSector::Number;
+    prove_commit_message.params =
+        codec::cbor::encode(ProveCommitSector::Params{sector_number, {}})
+            .value();
+    EXPECT_CALL(mock_ChainGetBlockMessages, Call(CID{block2}))
+        .WillOnce(
+            testing::Return(BlockMessages{{prove_commit_message}, {}, {}}));
+    EXPECT_CALL(mock_StateWaitMsg, Call(_, _, _, _, _))
+        .WillOnce(io_StateWaitMsg);
+    chainNotify(HeadChangeType::APPLY, block2);
+    EXPECT_CALL(cb, Call(void_success)).WillOnce(testing::Return());
+    io_run_one();
   }
 
   /**
@@ -106,16 +156,14 @@ namespace fc::markets::storage::chain_events {
    * @then future in wait status
    */
   TEST_F(ChainEventsTest, WaitCommitSector) {
-    api->ChainNotify = {[]() -> outcome::result<Chan<std::vector<HeadChange>>> {
-      auto channel{std::make_shared<Channel<std::vector<HeadChange>>>()};
-      return Chan{std::move(channel)};
-    }};
+    api::StorageDeal deal;
+    deal.state.sector_start_epoch = 1;
+    EXPECT_CALL(mock_StateMarketStorageDeal, Call(_, _))
+        .WillOnce(testing::Return(deal));
 
-    EXPECT_OUTCOME_TRUE_1(events->init());
-    bool is_called = false;
-    events->onDealSectorCommitted(
-        provider, deal_id, [&]() { is_called = true; });
-    EXPECT_FALSE(is_called);
+    MockCb cb;
+    EXPECT_CALL(cb, Call(void_success)).WillOnce(testing::Return());
+    events->onDealSectorCommitted(provider, deal_id, cb.AsStdFunction());
   }
 
 }  // namespace fc::markets::storage::chain_events

--- a/test/core/markets/storage/storage_market_deal_test.cpp
+++ b/test/core/markets/storage/storage_market_deal_test.cpp
@@ -20,8 +20,8 @@ namespace fc::markets::storage::test {
     EXPECT_CALL(*chain_events_, onDealSectorCommitted(_, _, _))
         // one for client and one for provider
         .Times(2)
-        .WillRepeatedly(
-            testing::Invoke([](auto arg1, auto arg2, auto cb) { cb(); }));
+        .WillRepeatedly(testing::Invoke(
+            [](auto, auto, auto cb) { cb(outcome::success()); }));
 
     EXPECT_OUTCOME_TRUE(data_ref, makeDataRef(CAR_FROM_PAYLOAD_FILE));
     ChainEpoch start_epoch{210};
@@ -97,8 +97,8 @@ namespace fc::markets::storage::test {
     EXPECT_CALL(*chain_events_, onDealSectorCommitted(_, _, _))
         // one for client and one for provider
         .Times(2)
-        .WillRepeatedly(
-            testing::Invoke([](auto arg1, auto arg2, auto cb) { cb(); }));
+        .WillRepeatedly(testing::Invoke(
+            [](auto, auto, auto cb) { cb(outcome::success()); }));
 
     // some unique valid CID of funding message
     CID client_funding_cid = "010001020002"_cid;
@@ -192,8 +192,8 @@ namespace fc::markets::storage::test {
     EXPECT_CALL(*chain_events_, onDealSectorCommitted(_, _, _))
         // one for client and one for provider
         .Times(2)
-        .WillRepeatedly(
-            testing::Invoke([](auto arg1, auto arg2, auto cb) { cb(); }));
+        .WillRepeatedly(testing::Invoke(
+            [](auto, auto, auto cb) { cb(outcome::success()); }));
 
     EXPECT_OUTCOME_TRUE(data_ref, makeDataRef(CAR_FROM_PAYLOAD_FILE));
     data_ref.transfer_type = kTransferTypeGraphsync;

--- a/test/testutil/mocks/markets/storage/chain_events/chain_events_mock.hpp
+++ b/test/testutil/mocks/markets/storage/chain_events/chain_events_mock.hpp
@@ -14,7 +14,7 @@ namespace fc::markets::storage::chain_events {
   class ChainEventsMock : public ChainEvents {
    public:
     MOCK_METHOD3(onDealSectorCommitted,
-                 void(const Address &, const DealId &, Cb));
+                 void(const Address &, const DealId &, CommitCb));
   };
 
 }  // namespace fc::markets::storage::chain_events


### PR DESCRIPTION
- outcome callback.
- detect missed precommit and commit messages.
- use `PreCommitBatch` and `ProveCommitAggregate` messages.
- remove unnecessary optional.
- simplify `makeEmptyMinerState `, `makeEmptyDeadlines`, `makeEmptyDeadline`.
- update test.