### PR TITLE
fix graphsync

### DIFF
--- a/core/common/libp2p/stream_proxy.hpp
+++ b/core/common/libp2p/stream_proxy.hpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/connection/stream.hpp>
+
+namespace libp2p::connection {
+  struct StreamProxy : Stream {
+    std::shared_ptr<Stream> stream;
+
+    explicit StreamProxy(std::shared_ptr<Stream> stream)
+        : stream{std::move(stream)} {}
+
+    void read(gsl::span<uint8_t> out,
+              size_t bytes,
+              ReadCallbackFunc cb) override {
+      stream->read(out, bytes, std::move(cb));
+    }
+    void readSome(gsl::span<uint8_t> out,
+                  size_t bytes,
+                  ReadCallbackFunc cb) override {
+      stream->readSome(out, bytes, std::move(cb));
+    }
+    void deferReadCallback(outcome::result<size_t> res,
+                           ReadCallbackFunc cb) override {
+      stream->deferReadCallback(res, std::move(cb));
+    }
+
+    void write(gsl::span<const uint8_t> in,
+               size_t bytes,
+               WriteCallbackFunc cb) override {
+      stream->write(in, bytes, std::move(cb));
+    }
+    void writeSome(gsl::span<const uint8_t> in,
+                   size_t bytes,
+                   WriteCallbackFunc cb) override {
+      stream->writeSome(in, bytes, std::move(cb));
+    }
+    void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override {
+      stream->deferWriteCallback(ec, std::move(cb));
+    }
+
+    bool isClosedForRead() const override {
+      return stream->isClosedForRead();
+    }
+    bool isClosedForWrite() const override {
+      return stream->isClosedForWrite();
+    }
+    bool isClosed() const override {
+      return stream->isClosed();
+    }
+    void close(VoidResultHandlerFunc cb) override {
+      stream->close(std::move(cb));
+    }
+    void reset() override {
+      stream->reset();
+    }
+    void adjustWindowSize(uint32_t new_size,
+                          VoidResultHandlerFunc cb) override {
+      stream->adjustWindowSize(new_size, std::move(cb));
+    }
+    outcome::result<bool> isInitiator() const override {
+      return stream->isInitiator();
+    }
+    outcome::result<peer::PeerId> remotePeerId() const override {
+      return stream->remotePeerId();
+    }
+    outcome::result<multi::Multiaddress> localMultiaddr() const override {
+      return stream->localMultiaddr();
+    }
+    outcome::result<multi::Multiaddress> remoteMultiaddr() const override {
+      return stream->remoteMultiaddr();
+    }
+  };
+}  // namespace libp2p::connection

--- a/core/common/libp2p/stream_read_buffer.hpp
+++ b/core/common/libp2p/stream_read_buffer.hpp
@@ -1,0 +1,77 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common/bytes.hpp"
+#include "common/libp2p/stream_proxy.hpp"
+#include "common/outcome.hpp"
+
+namespace libp2p::connection {
+  using fc::Bytes;
+  using fc::BytesOut;
+
+  struct StreamReadBuffer : StreamProxy,
+                            std::enable_shared_from_this<StreamReadBuffer> {
+    std::shared_ptr<Bytes> buffer;
+    size_t begin{};
+    size_t end{};
+
+    StreamReadBuffer(std::shared_ptr<Stream> stream, size_t capacity)
+        : StreamProxy{std::move(stream)},
+          buffer{std::make_shared<Bytes>(capacity)} {}
+
+    size_t size() const {
+      return end - begin;
+    }
+
+    void readFull(BytesOut out, size_t n, ReadCallbackFunc cb) {
+      readSome(out,
+               out.size(),
+               [weak{weak_from_this()}, out, n, cb{std::move(cb)}](
+                   outcome::result<size_t> _r) {
+                 OUTCOME_CB(auto r, _r);
+                 if (auto self{weak.lock()}) {
+                   const auto _r{static_cast<ptrdiff_t>(r)};
+                   assert(_r <= out.size());
+                   if (_r == out.size()) {
+                     return cb(n);
+                   }
+                   self->readFull(out.subspan(r), n, std::move(cb));
+                 }
+               });
+    }
+
+    void read(BytesOut out, size_t n, ReadCallbackFunc cb) override {
+      assert(out.size() >= static_cast<ptrdiff_t>(n));
+      readFull(out.first(n), n, std::move(cb));
+    }
+
+    void readSome(BytesOut out, size_t n, ReadCallbackFunc cb) override {
+      assert(out.size() >= static_cast<ptrdiff_t>(n));
+      if (n == 0) {
+        return cb(n);
+      }
+      if (size() != 0) {
+        n = std::min(n, size());
+        std::copy_n(buffer->begin() + begin, n, out.begin());
+        begin += n;
+        return cb(n);
+      }
+      stream->readSome(
+          *buffer,
+          buffer->size(),
+          [weak{weak_from_this()}, out, n, cb{std::move(cb)}, buffer{buffer}](
+              outcome::result<size_t> _r) {
+            OUTCOME_CB(auto r, _r);
+            if (auto self{weak.lock()}) {
+              self->begin = 0;
+              self->end = r;
+              self->readSome(out, n, std::move(cb));
+            }
+          });
+    }
+  };
+}  // namespace libp2p::connection

--- a/core/const.cpp
+++ b/core/const.cpp
@@ -124,7 +124,10 @@ namespace fc {
         540 * kEpochsInDay;
     vm::actor::builtin::types::miner::kMaxProveCommitDuration =
         kEpochsInDay + kPreCommitChallengeDelay;
-    kSupportedProofs = {RegisteredSealProof::kStackedDrg2KiBV1};
+    kSupportedProofs = {
+        RegisteredSealProof::kStackedDrg2KiBV1,
+        RegisteredSealProof::kStackedDrg8MiBV1,
+    };
 
     vm::actor::builtin::types::payment_channel::kSettleDelay =
         kEpochsInHour * 12;

--- a/core/data_transfer/dt.cpp
+++ b/core/data_transfer/dt.cpp
@@ -154,8 +154,7 @@ namespace fc::data_transfer {
                                 OkCb on_end) {
     auto sub{std::make_shared<Subscription>()};
     *sub = gs->makeRequest(
-        pdtid.peer,
-        {},
+        {pdtid.peer, {}},
         root,
         kAllSelector.b,
         {makeExt(DataTransferResponse{
@@ -202,13 +201,8 @@ namespace fc::data_transfer {
     PeerDtId pdtid{peer.id, dtid};
     pulling_out.emplace(pdtid, std::move(on_reply));
     auto sub{std::make_shared<Subscription>()};
-    boost::optional<libp2p::multi::Multiaddress> addr;
-    if (!peer.addresses.empty()) {
-      addr = peer.addresses[0];
-    }
     *sub = gs->makeRequest(
-        peer.id,
-        addr,
+        peer,
         root,
         selector.b,
         {makeExt(DataTransferRequest{

--- a/core/markets/retrieval/client/impl/retrieval_client_impl.cpp
+++ b/core/markets/retrieval/client/impl/retrieval_client_impl.cpp
@@ -98,15 +98,16 @@ namespace fc::markets::retrieval::client {
             auto unseal{res.status == DealStatus::kDealStatusFundsNeededUnseal};
             const auto last{res.status
                             == DealStatus::kDealStatusFundsNeededLastPayment};
-            deal->accepted =
-                unseal || res.status == DealStatus::kDealStatusAccepted || last;
+            const auto done{res.status == DealStatus::kDealStatusCompleted};
+            const auto accepted{res.status == DealStatus::kDealStatusAccepted};
+            deal->accepted = unseal || accepted || last || done;
             if (!deal->accepted) {
               deal->handler(
                   res.status == DealStatus::kDealStatusRejected
                       ? RetrievalClientError::kResponseDealRejected
-                      : res.status == DealStatus::kDealStatusDealNotFound
-                            ? RetrievalClientError::kResponseNotFound
-                            : RetrievalClientError::kUnknownResponseReceived);
+                  : res.status == DealStatus::kDealStatusDealNotFound
+                      ? RetrievalClientError::kResponseNotFound
+                      : RetrievalClientError::kUnknownResponseReceived);
               datatransfer_->pulling_out.erase(deal->pdtid);
               return;
             }

--- a/core/markets/retrieval/client/impl/retrieval_client_impl.hpp
+++ b/core/markets/retrieval/client/impl/retrieval_client_impl.hpp
@@ -116,7 +116,7 @@ namespace fc::markets::retrieval::client {
     void failDeal(const std::shared_ptr<DealState> &deal_state,
                   const std::error_code &error);
 
-    DealId next_deal_id;
+    DealId next_deal_id{};
     std::shared_ptr<Host> host_;
     std::shared_ptr<DataTransfer> datatransfer_;
     std::shared_ptr<FullNodeApi> api_;

--- a/core/markets/storage/client/impl/storage_market_client_impl.cpp
+++ b/core/markets/storage/client/impl/storage_market_client_impl.cpp
@@ -116,6 +116,8 @@ namespace fc::markets::storage::client {
           } else {
             spdlog::error(
                 "askDealStatus {} {}", deal->proposal_cid, _res.error());
+            std::lock_guard lock{waiting_mutex};
+            waiting_deals.push_back(deal);
           }
         })};
     DealStatusRequest req;

--- a/core/node/main/builder.cpp
+++ b/core/node/main/builder.cpp
@@ -286,7 +286,7 @@ namespace fc::node {
             node_objects.api,
             node_objects.chain_events,
             std::make_shared<PieceIOImpl>("/tmp/fuhon/piece_io"));
-    // timer is set to 100 ms
+    // timer is set to 5000 ms
     timerLoop(node_objects.scheduler,
               std::chrono::milliseconds(5000),
               [client{node_objects.storage_market_client}] {

--- a/core/node/main/builder.cpp
+++ b/core/node/main/builder.cpp
@@ -288,7 +288,7 @@ namespace fc::node {
             std::make_shared<PieceIOImpl>("/tmp/fuhon/piece_io"));
     // timer is set to 100 ms
     timerLoop(node_objects.scheduler,
-              std::chrono::milliseconds(100),
+              std::chrono::milliseconds(5000),
               [client{node_objects.storage_market_client}] {
                 client->pollWaiting();
               });

--- a/core/node/main/main.cpp
+++ b/core/node/main/main.cpp
@@ -268,8 +268,8 @@ namespace fc {
                       res.error());
       }
     })};
-    o.api->MpoolPushMessage = [&, impl{std::move(o.api->MpoolPushMessage)}](
-                                  auto &arg1, auto &arg2) {
+    o.api->MpoolPushMessage = [&, impl{o.api->MpoolPushMessage}](auto &arg1,
+                                                                 auto &arg2) {
       auto res{impl(arg1, arg2)};
       if (res) {
         o.pubsub_gate->publish(res.value());

--- a/core/node/main/main.cpp
+++ b/core/node/main/main.cpp
@@ -244,6 +244,8 @@ namespace fc {
   }
 
   void main(node::Config &config) {
+    const auto start_time{Metrics::Clock::now()};
+
     vm::actor::cgo::configParams();
 
     if (config.log_level <= spdlog::level::debug) {
@@ -277,7 +279,7 @@ namespace fc {
       return res;
     };
 
-    Metrics metrics{o};
+    Metrics metrics{o, start_time};
 
     o.io_context->post([&] {
       for (auto &host : config.drand_servers) {

--- a/core/payment_channel_manager/impl/payment_channel_manager_impl.cpp
+++ b/core/payment_channel_manager/impl/payment_channel_manager_impl.cpp
@@ -33,6 +33,7 @@ namespace fc::payment_channel_manager {
       std::shared_ptr<FullNodeApi> api, std::shared_ptr<Ipld> ipld)
       : api_{std::move(api)}, ipld_{std::move(ipld)} {}
 
+  // TODO(turuslan): check concurrent creation/duplication/reuse
   void PaymentChannelManagerImpl::getOrCreatePaymentChannel(
       const Address &client,
       const Address &miner,
@@ -43,7 +44,19 @@ namespace fc::payment_channel_manager {
       // TODO track available funds
       OUTCOME_CB(auto cid,
                  addFunds(*channel_address, client, amount_available));
-      return cb(AddChannelInfo{*channel_address, cid});
+      api_->StateWaitMsg(
+          [=, self{shared_from_this()}, cb{std::move(cb)}](auto _wait) {
+            OUTCOME_CB(auto wait, _wait);
+            if (wait.receipt.exit_code != VMExitCode::kOk) {
+              return cb(PaymentChannelManagerError::kSendFundsErrored);
+            }
+            cb(AddChannelInfo{*channel_address, cid});
+          },
+          cid,
+          kMessageConfidence,
+          api::kLookbackNoLimit,
+          true);
+      return;
     }
     OUTCOME_CB(auto cid,
                createPaymentChannelActor(client, miner, amount_available));
@@ -259,16 +272,7 @@ namespace fc::payment_channel_manager {
         {}};
     OUTCOME_TRY(signed_message,
                 api_->MpoolPushMessage(unsigned_message, api::kPushNoSpec));
-    auto message_cid{signed_message.getCid()};
-    // TODO: maybe async call, it's long
-    OUTCOME_TRY(
-        message_state,
-        api_->StateWaitMsg(
-            message_cid, kMessageConfidence, api::kLookbackNoLimit, true));
-    if (message_state.receipt.exit_code != VMExitCode::kOk) {
-      return PaymentChannelManagerError::kSendFundsErrored;
-    }
-    return std::move(message_cid);
+    return signed_message.getCid();
   }
 
   outcome::result<CID> PaymentChannelManagerImpl::createPaymentChannelActor(

--- a/core/storage/ipfs/graphsync/graphsync.hpp
+++ b/core/storage/ipfs/graphsync/graphsync.hpp
@@ -10,7 +10,7 @@
 #include <boost/optional.hpp>
 #include <boost/signals2.hpp>
 #include <libp2p/multi/multiaddress.hpp>
-#include <libp2p/peer/peer_id.hpp>
+#include <libp2p/peer/peer_info.hpp>
 #include <libp2p/protocol/common/subscription.hpp>
 
 #include "common/buffer.hpp"
@@ -20,6 +20,7 @@
 
 namespace fc::storage::ipfs::graphsync {
   using libp2p::peer::PeerId;
+  using libp2p::peer::PeerInfo;
 
   /// Subscription to any data stream, borrowed from libp2p
   using libp2p::protocol::Subscription;
@@ -138,20 +139,17 @@ namespace fc::storage::ipfs::graphsync {
 
     /// Initiates a new request to graphsync network
     /// \param peer Peer ID
-    /// \param address Optional peer network address
     /// \param root_cid Root CID of the request
     /// \param selector IPLD selector
     /// \param extensions - extension data
     /// \param callback A callback which keeps track of request progress
     /// \return Subscription object. Request is cancelled as soon as
     /// this subscription is cancelled or goes out of scope
-    virtual Subscription makeRequest(
-        const libp2p::peer::PeerId &peer,
-        boost::optional<libp2p::multi::Multiaddress> address,
-        const CID &root_cid,
-        gsl::span<const uint8_t> selector,
-        const std::vector<Extension> &extensions,
-        RequestProgressCallback callback) = 0;
+    virtual Subscription makeRequest(const libp2p::peer::PeerInfo &peer,
+                                     const CID &root_cid,
+                                     gsl::span<const uint8_t> selector,
+                                     const std::vector<Extension> &extensions,
+                                     RequestProgressCallback callback) = 0;
   };
 
 }  // namespace fc::storage::ipfs::graphsync

--- a/core/storage/ipfs/graphsync/impl/graphsync_impl.cpp
+++ b/core/storage/ipfs/graphsync/impl/graphsync_impl.cpp
@@ -88,15 +88,14 @@ namespace fc::storage::ipfs::graphsync {
   }
 
   Subscription GraphsyncImpl::makeRequest(
-      const libp2p::peer::PeerId &peer,
-      boost::optional<libp2p::multi::Multiaddress> address,
+      const libp2p::peer::PeerInfo &peer,
       const CID &root_cid,
       gsl::span<const uint8_t> selector,
       const std::vector<Extension> &extensions,
       RequestProgressCallback callback) {
-    if (!started_ || !network_->canSendRequest(peer)) {
+    if (!started_ || !network_->canSendRequest(peer.id)) {
       logger()->trace("makeRequest: rejecting request to peer {}",
-                      peer.toBase58().substr(46));
+                      peer.id.toBase58().substr(46));
       return local_requests_->newRejectedRequest(std::move(callback));
     }
 
@@ -112,12 +111,10 @@ namespace fc::storage::ipfs::graphsync {
       assert(!newRequest.body->empty());
 
       logger()->trace("makeRequest: sending request to peer {}",
-                      peer.toBase58().substr(46));
+                      peer.id.toBase58().substr(46));
 
-      network_->makeRequest(peer,
-                            std::move(address),
-                            newRequest.request_id,
-                            std::move(newRequest.body));
+      network_->makeRequest(
+          peer, newRequest.request_id, std::move(newRequest.body));
     }
 
     return std::move(newRequest.subscription);

--- a/core/storage/ipfs/graphsync/impl/graphsync_impl.hpp
+++ b/core/storage/ipfs/graphsync/impl/graphsync_impl.hpp
@@ -46,13 +46,11 @@ namespace fc::storage::ipfs::graphsync {
                       const Response &response) override;
     void start() override;
     void stop() override;
-    Subscription makeRequest(
-        const libp2p::peer::PeerId &peer,
-        boost::optional<libp2p::multi::Multiaddress> address,
-        const CID &root_cid,
-        gsl::span<const uint8_t> selector,
-        const std::vector<Extension> &extensions,
-        RequestProgressCallback callback) override;
+    Subscription makeRequest(const libp2p::peer::PeerInfo &peer,
+                             const CID &root_cid,
+                             gsl::span<const uint8_t> selector,
+                             const std::vector<Extension> &extensions,
+                             RequestProgressCallback callback) override;
 
     // PeerToGraphsyncFeedback interface overrides
     void onResponse(const PeerId &peer,

--- a/core/storage/ipfs/graphsync/impl/network/network.cpp
+++ b/core/storage/ipfs/graphsync/impl/network/network.cpp
@@ -31,7 +31,7 @@ namespace fc::storage::ipfs::graphsync {
     // clang-format off
     host_->setProtocolHandler(
         protocol_id_,
-        [wptr = weak_from_this()] (outcome::result<StreamPtr> rstream) {
+        [wptr = weak_from_this()] (StreamPtr rstream) {
           auto self = wptr.lock();
           if (self) { self->onStreamAccepted(std::move(rstream)); }
         }
@@ -153,17 +153,12 @@ namespace fc::storage::ipfs::graphsync {
     return ctx;
   }
 
-  void Network::onStreamAccepted(outcome::result<StreamPtr> rstream) {
+  void Network::onStreamAccepted(StreamPtr rstream) {
     if (!started_) {
       return;
     }
 
-    if (!rstream) {
-      logger()->error("accept error, msg='{}'", rstream.error().message());
-      return;
-    }
-
-    auto peer_id_res = rstream.value()->remotePeerId();
+    auto peer_id_res = rstream->remotePeerId();
     if (!peer_id_res) {
       logger()->error("no peer id for accepted stream, msg='{}'",
                       peer_id_res.error().message());
@@ -174,7 +169,7 @@ namespace fc::storage::ipfs::graphsync {
 
     logger()->trace("accepted stream from peer={}", ctx->str);
 
-    ctx->onStreamAccepted(std::move(rstream.value()));
+    ctx->onStreamAccepted(std::move(rstream));
   }
 
   void Network::closeAllPeers() {

--- a/core/storage/ipfs/graphsync/impl/network/network.hpp
+++ b/core/storage/ipfs/graphsync/impl/network/network.hpp
@@ -15,6 +15,7 @@
 
 namespace fc::storage::ipfs::graphsync {
   using libp2p::basic::Scheduler;
+  using libp2p::peer::PeerInfo;
 
   /// Network part of graphsync component
   class Network : public std::enable_shared_from_this<Network>,
@@ -46,8 +47,7 @@ namespace fc::storage::ipfs::graphsync {
     /// \param address optional network address
     /// \param request_id request ID
     /// \param request_body serialized request data
-    void makeRequest(const PeerId &peer,
-                     boost::optional<libp2p::multi::Multiaddress> address,
+    void makeRequest(const PeerInfo &peer,
                      RequestId request_id,
                      SharedData request_body);
 

--- a/core/storage/ipfs/graphsync/impl/network/network.hpp
+++ b/core/storage/ipfs/graphsync/impl/network/network.hpp
@@ -74,7 +74,7 @@ namespace fc::storage::ipfs::graphsync {
 
     /// Libp2p network server callback
     /// \param rstream Accept result, contains a new inbound stream on success
-    void onStreamAccepted(outcome::result<StreamPtr> rstream);
+    void onStreamAccepted(StreamPtr rstream);
 
     /// Closes all peers gracefully
     void closeAllPeers();

--- a/core/storage/ipfs/graphsync/impl/network/peer_context.cpp
+++ b/core/storage/ipfs/graphsync/impl/network/peer_context.cpp
@@ -67,10 +67,8 @@ namespace fc::storage::ipfs::graphsync {
   }
 
   void PeerContext::setOutboundAddress(
-      boost::optional<libp2p::multi::Multiaddress> connect_to) {
-    if (connect_to) {
-      connect_to_ = std::move(connect_to);
-    }
+      std::vector<libp2p::multi::Multiaddress> connect_to) {
+    connect_to_ = std::move(connect_to);
   }
 
   void PeerContext::connectIfNeeded() {
@@ -81,19 +79,11 @@ namespace fc::storage::ipfs::graphsync {
     if (!outbound_endpoint_) {
       outbound_endpoint_ = std::make_unique<OutboundEndpoint>();
 
-      logger()->debug("connecting to {}, {}",
-                      str,
-                      connect_to_ ? connect_to_->getStringAddress()
-                                  : "existing connection");
-
-      libp2p::peer::PeerInfo pi{peer, {}};
-      if (connect_to_) {
-        pi.addresses.push_back(connect_to_.value());
-      }
+      logger()->debug("connecting to {}", str);
 
       // clang-format off
       host_.newStream(
-          std::move(pi),
+          {peer, connect_to_},
           std::string(kProtocolVersion),
           [wptr{weak_from_this()}]
               (outcome::result<StreamPtr> rstream) {
@@ -121,7 +111,6 @@ namespace fc::storage::ipfs::graphsync {
       if (getState() == is_connecting) {
         closeLocalRequests(RS_CANNOT_CONNECT);
       }
-      connect_to_.reset();
     }
   }
 

--- a/core/storage/ipfs/graphsync/impl/network/peer_context.cpp
+++ b/core/storage/ipfs/graphsync/impl/network/peer_context.cpp
@@ -7,7 +7,9 @@
 
 #include <libp2p/connection/stream.hpp>
 #include <libp2p/host/host.hpp>
+#include <libp2p/security/noise/crypto/state.hpp>
 
+#include "common/libp2p/stream_read_buffer.hpp"
 #include "message_queue.hpp"
 #include "message_reader.hpp"
 #include "outbound_endpoint.hpp"
@@ -124,6 +126,11 @@ namespace fc::storage::ipfs::graphsync {
   }
 
   void PeerContext::onNewStream(StreamPtr stream, bool is_outbound) {
+    if (stream) {
+      stream = std::make_shared<libp2p::connection::StreamReadBuffer>(
+          stream, libp2p::security::noise::kMaxMsgLen);
+    }
+
     assert(stream);
     assert(streams_.count(stream) == 0);
 

--- a/core/storage/ipfs/graphsync/impl/network/peer_context.hpp
+++ b/core/storage/ipfs/graphsync/impl/network/peer_context.hpp
@@ -50,7 +50,7 @@ namespace fc::storage::ipfs::graphsync {
     /// Stores network address for outbound connections. May be updated.
     /// \param connect_to address, optional
     void setOutboundAddress(
-        boost::optional<libp2p::multi::Multiaddress> connect_to);
+        std::vector<libp2p::multi::Multiaddress> connect_to);
 
     /// Internal state
     enum State { can_connect, is_connecting, is_connected, is_closed };
@@ -163,7 +163,7 @@ namespace fc::storage::ipfs::graphsync {
     Scheduler &scheduler_;
 
     /// Outbound address
-    boost::optional<libp2p::multi::Multiaddress> connect_to_;
+    std::vector<libp2p::multi::Multiaddress> connect_to_;
 
     /// The only one per peer sending endpoint
     std::unique_ptr<OutboundEndpoint> outbound_endpoint_;

--- a/core/vm/actor/builtin/types/miner/policy.hpp
+++ b/core/vm/actor/builtin/types/miner/policy.hpp
@@ -125,7 +125,7 @@ namespace fc::vm::actor::builtin::types::miner {
                                         const DealWeight &deal_weight,
                                         const DealWeight &verified_weight) {
     const auto sector_space_time = size * duration;
-    const auto total_deal_space_time = deal_weight * verified_weight;
+    const auto total_deal_space_time = deal_weight + verified_weight;
     assert(sector_space_time >= total_deal_space_time);
 
     const auto weighted_base_space_time =

--- a/core/vm/actor/builtin/types/miner/v0/monies.cpp
+++ b/core/vm/actor/builtin/types/miner/v0/monies.cpp
@@ -29,7 +29,7 @@ namespace fc::vm::actor::builtin::v0::miner {
       const NetworkVersion &network_version) {
     ChainEpoch projection_period = declared_fault_projection_period_v0;
     if (network_version >= NetworkVersion::kVersion3) {
-      projection_period = declared_fault_factor_num_v3;
+      projection_period = declared_fault_projection_period_v3;
     }
     return expectedRewardForPower(reward_estimate,
                                   network_power_estimate,

--- a/test/core/storage/ipfs/graphsync/graphsync_acceptance_common.cpp
+++ b/test/core/storage/ipfs/graphsync/graphsync_acceptance_common.cpp
@@ -16,12 +16,6 @@ namespace fc::storage::ipfs::graphsync::test {
 
   void runEventLoop(const std::shared_ptr<boost::asio::io_context> &io,
                     size_t max_milliseconds) {
-    boost::asio::signal_set signals(*io, SIGINT, SIGTERM);
-
-    // io->run() can exit if we're not waiting for anything
-    signals.async_wait(
-        [&io](const boost::system::error_code &, int) { io->stop(); });
-
     if (max_milliseconds > 0) {
       io->run_for(std::chrono::milliseconds(max_milliseconds));
     } else {

--- a/test/core/storage/ipfs/graphsync/graphsync_acceptance_test.cpp
+++ b/test/core/storage/ipfs/graphsync/graphsync_acceptance_test.cpp
@@ -65,18 +65,11 @@ namespace fc::storage::ipfs::graphsync::test {
     }
 
     // calls Graphsync's makeRequest
-    void makeRequest(const libp2p::peer::PeerId &peer,
-                     boost::optional<libp2p::multi::Multiaddress> address,
-                     const CID &root_cid) {
+    void makeRequest(const PeerInfo &peer, const CID &root_cid) {
       start();
 
-      std::vector<Extension> extensions;
-      requests_.push_back(graphsync_->makeRequest(peer,
-                                                  std::move(address),
-                                                  root_cid,
-                                                  {},
-                                                  extensions,
-                                                  requestProgressCallback()));
+      requests_.push_back(graphsync_->makeRequest(
+          peer, root_cid, {}, {}, requestProgressCallback()));
       ++requests_sent;
     }
 
@@ -204,16 +197,11 @@ namespace fc::storage::ipfs::graphsync::test {
       // server listens
       server.listen(listen_to);
       auto peer = server.getId();
-      bool use_address = true;
 
       // client makes 3 requests
 
       for (const auto &[cid, _] : client_data->getExpected()) {
-        boost::optional<libp2p::multi::Multiaddress> address(listen_to);
-
-        // don't need to pass the address more than once
-        client.makeRequest(peer, use_address ? address : boost::none, cid);
-        use_address = false;
+        client.makeRequest({peer, {listen_to}}, cid);
       }
     });
 
@@ -352,7 +340,7 @@ namespace fc::storage::ipfs::graphsync::test {
                 // data block,
                 // and respectively RS_NOT_FOUND will come N-2 times per block
 
-                n.makeRequest(p0.peer.value(), p0.listen_to, cid);
+                n.makeRequest({*p0.peer, {*p0.listen_to}}, cid);
               }
             }
           }

--- a/test/core/vm/actor/builtin/types/miner/monies_test_v2.cpp
+++ b/test/core/vm/actor/builtin/types/miner/monies_test_v2.cpp
@@ -50,7 +50,7 @@ namespace fc::vm::actor::builtin::v2::miner {
 
   TEST_F(MoniesTestv2, TestPledgePenaltyForTermination) {
     const TokenAmount initial_pledge = TokenAmount{1 << 10};
-    day_reward = initial_pledge, big_initial_pledge_factor;
+    day_reward = bigdiv(initial_pledge, big_initial_pledge_factor);
     twenty_day_reward = day_reward * big_initial_pledge_factor;
     sector_age = 20 * ChainEpoch{static_cast<BigInt>(kEpochsInDay)};
 


### PR DESCRIPTION
- `StreamReadBuffer` yamux workaround, used in graphsync.
- `StreamProxy` wrapper base.
- refactor graphsync from `PeerId + optional<Multiaddress>` to `PeerInfo`.
- retrieval client "accepted" check.
- storage client retry polling on error.
- longer storage client polling interval.
- fix `MpoolPushMessage`.
- `uptime` metric in seconds.
- paych `addFunds` deadlock.
- fix typos.