### PR TITLE
clang-tidy fixes

### DIFF
--- a/core/common/ffi.hpp
+++ b/core/common/ffi.hpp
@@ -16,6 +16,7 @@ namespace fc::common::ffi {
   }
 
   template <size_t size>
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
   auto array(const uint8_t (&rhs)[size]) {
     Blob<size> lhs;
     std::copy(std::begin(rhs), std::end(rhs), std::begin(lhs));
@@ -23,6 +24,7 @@ namespace fc::common::ffi {
   }
 
   template <size_t size>
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
   void array(uint8_t (&lhs)[size], const std::array<uint8_t, size> rhs) {
     std::copy(std::begin(rhs), std::end(rhs), std::begin(lhs));
   }

--- a/core/common/libp2p/cbor_buffering.cpp
+++ b/core/common/libp2p/cbor_buffering.cpp
@@ -12,7 +12,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(fc::common::libp2p, CborBuffering::Error, e) {
 namespace fc::common::libp2p {
   using Head = CborBuffering::Head;
 
-  outcome::result<Head> Head::first(size_t &more, uint8_t first) {
+  outcome::result<Head> Head::first(ssize_t &more, uint8_t first) {
     // https://tools.ietf.org/html/rfc7049#section-2
     // decode major type
     auto type = Type{(first & 0xe0) >> 5};
@@ -57,7 +57,7 @@ namespace fc::common::libp2p {
     return head;
   }
 
-  void Head::next(size_t &more, uint8_t next, Head &head) {
+  void Head::next(ssize_t &more, uint8_t next, Head &head) {
     assert(more > 0);
     --more;
     head.value = (head.value << 8) | next;
@@ -76,11 +76,11 @@ namespace fc::common::libp2p {
     return more_bytes != 0 ? more_bytes : more_nested.empty() ? 0 : 1;
   }
 
-  outcome::result<size_t> CborBuffering::consume(
+  outcome::result<ssize_t> CborBuffering::consume(
       gsl::span<const uint8_t> input) {
     assert(!done());
-    auto size = static_cast<size_t>(input.size());
-    size_t consumed = 0;
+    ssize_t size = input.size();
+    ssize_t consumed = 0;
     if (!partial_head && more_bytes != 0) {
       auto partial = std::min(more_bytes, size - consumed);
       more_bytes -= partial;
@@ -111,8 +111,7 @@ namespace fc::common::libp2p {
           break;
         case Type::Bytes:
         case Type::Text: {
-          auto partial =
-              std::min(static_cast<size_t>(head.value), size - consumed);
+          auto partial = std::min(head.value, size - consumed);
           consumed += partial;
           more_bytes = head.value - partial;
           break;

--- a/core/common/libp2p/cbor_buffering.hpp
+++ b/core/common/libp2p/cbor_buffering.hpp
@@ -33,13 +33,13 @@ namespace fc::common::libp2p {
 
     struct Head {
       /// Parse first header byte
-      static outcome::result<Head> first(size_t &more, uint8_t first);
+      static outcome::result<Head> first(ssize_t &more, uint8_t first);
 
       /// Parse next header byte
-      static void next(size_t &more, uint8_t next, Head &head);
+      static void next(ssize_t &more, uint8_t next, Head &head);
 
       Type type;
-      uint64_t value;
+      ssize_t value;
     };
 
     /// Was object fully read
@@ -52,10 +52,10 @@ namespace fc::common::libp2p {
     size_t moreBytes() const;
 
     /// Continue reading, return bytes consumed
-    outcome::result<size_t> consume(gsl::span<const uint8_t> input);
+    outcome::result<ssize_t> consume(gsl::span<const uint8_t> input);
 
     std::vector<size_t> more_nested;
-    size_t more_bytes{};
+    ssize_t more_bytes{};
     boost::optional<Head> partial_head;
   };
 }  // namespace fc::common::libp2p

--- a/core/common/libp2p/cbor_stream.cpp
+++ b/core/common/libp2p/cbor_stream.cpp
@@ -24,9 +24,7 @@ namespace fc::common::libp2p {
                             WriteCallbackFunc cb) {
     stream_->write(*input,
                    input->size(),
-                   [input{std::move(input)}, cb{std::move(cb)}](auto written) {
-                     cb(written);
-                   });
+                   [input, cb{std::move(cb)}](auto written) { cb(written); });
   }
 
   void CborStream::readMore(ReadCallbackFunc cb) {

--- a/core/common/libp2p/cbor_stream.cpp
+++ b/core/common/libp2p/cbor_stream.cpp
@@ -24,7 +24,9 @@ namespace fc::common::libp2p {
                             WriteCallbackFunc cb) {
     stream_->write(*input,
                    input->size(),
-                   [input, cb{std::move(cb)}](auto written) { cb(written); });
+                   [input{std::move(input)}, cb{std::move(cb)}](auto written) {
+                     cb(written);
+                   });
   }
 
   void CborStream::readMore(ReadCallbackFunc cb) {
@@ -40,8 +42,7 @@ namespace fc::common::libp2p {
             return cb(count.error());
           }
           self->buffer_.resize(self->size_ + count.value());
-          self->consume(gsl::make_span(self->buffer_).subspan(self->size_),
-                        std::move(cb));
+          self->consume(gsl::make_span(self->buffer_).subspan(self->size_), cb);
         });
   }
 

--- a/core/common/libp2p/cbor_stream.hpp
+++ b/core/common/libp2p/cbor_stream.hpp
@@ -51,13 +51,12 @@ namespace fc::common::libp2p {
 
     /// Write cbor object
     template <typename T>
-    void write(const T &value, WriteCallbackFunc cb) {
+    void write(const T &value, const WriteCallbackFunc &cb) {
       auto maybe_encoded = codec::cbor::encode(value);
       if (!maybe_encoded) {
         return cb(maybe_encoded.error());
       }
-      writeRaw(std::make_shared<Buffer>(std::move(maybe_encoded.value())),
-               std::move(cb));
+      writeRaw(std::make_shared<Buffer>(std::move(maybe_encoded.value())), cb);
     }
 
     void close() {
@@ -71,6 +70,6 @@ namespace fc::common::libp2p {
     std::shared_ptr<Stream> stream_;
     CborBuffering buffering_;
     std::vector<uint8_t> buffer_;
-    size_t size_{};
+    ssize_t size_{};
   };
 }  // namespace fc::common::libp2p

--- a/core/common/logger.cpp
+++ b/core/common/logger.cpp
@@ -29,6 +29,7 @@ namespace {
 }  // namespace
 
 namespace fc::common {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   decltype(file_sink) file_sink;
 
   Logger createLogger(const std::string &tag) {

--- a/core/common/uri_parser/CMakeLists.txt
+++ b/core/common/uri_parser/CMakeLists.txt
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_library(uri_parser
-        uri_parser.cpp
-        percent_encoding.cpp
-        )
+    uri_parser.cpp
+    percent_encoding.cpp
+    )
+# any library is linked to include GSL
+target_link_libraries(uri_parser
+    outcome
+    )

--- a/core/common/uri_parser/percent_encoding.cpp
+++ b/core/common/uri_parser/percent_encoding.cpp
@@ -25,6 +25,7 @@
 
 #include "common/uri_parser/percent_encoding.hpp"
 
+#include <gsl/gsl_util>
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
@@ -106,7 +107,7 @@ static uint32_t decodePercentEscaped(std::istringstream &iss, bool &isUtf8) {
     return static_cast<uint32_t>(c);
   }
 
-  int bytes;
+  int bytes = 0;
   uint32_t symbol = 0;
   if ((c & 0b11111100) == 0b11111100) {
     bytes = 6;
@@ -141,12 +142,12 @@ static uint32_t decodePercentEscaped(std::istringstream &iss, bool &isUtf8) {
     try {
       c = decodePercentEscapedByte(iss);
     } catch (...) {
-      iss.clear(iss.goodbit);
+      iss.clear(std::istringstream::goodbit);
       iss.seekg(p);
       return static_cast<uint32_t>(fc);
     }
     if ((c & 0b11000000) != 0b10000000) {
-      iss.clear(iss.goodbit);
+      iss.clear(std::istringstream::goodbit);
       iss.seekg(p);
       return static_cast<uint32_t>(fc);
     }
@@ -168,66 +169,66 @@ std::string PercentEncoding::decode(const std::string &input) {
 
       if (symbol <= 0b0111'1111)  // 7bit -> 1byte
       {
-        oss.put(static_cast<uint8_t>(symbol));
+        oss.put(gsl::narrow_cast<uint8_t>(symbol));
       } else if (symbol <= 0b0111'1111'1111)  // 11bit -> 2byte
       {
-        oss.put(
-            static_cast<uint8_t>(0b1100'0000 | (0b0001'1111 & (symbol >> 6))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 0))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1100'0000
+                                          | (0b0001'1111 & (symbol >> 6))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 0))));
       } else if (symbol <= 0b1111'1111'1111'1111)  // 16bit -> 3byte
       {
-        oss.put(
-            static_cast<uint8_t>(0b1110'0000 | (0b0000'1111 & (symbol >> 12))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 6))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 0))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1110'0000
+                                          | (0b0000'1111 & (symbol >> 12))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 6))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 0))));
       } else if (symbol <= 0b0001'1111'1111'1111'1111'1111)  // 21bit -> 4byte
       {
-        oss.put(
-            static_cast<uint8_t>(0b1111'0000 | (0b0000'0111 & (symbol >> 18))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 12))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 6))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 0))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1111'0000
+                                          | (0b0000'0111 & (symbol >> 18))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 12))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 6))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 0))));
       } else if (symbol
                  <= 0b0011'1111'1111'1111'1111'1111'1111)  // 26bit -> 5byte
       {
-        oss.put(
-            static_cast<uint8_t>(0b1111'1000 | (0b0000'0011 & (symbol >> 24))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 18))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 12))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 6))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 0))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1111'1000
+                                          | (0b0000'0011 & (symbol >> 24))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 18))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 12))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 6))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 0))));
       } else if (symbol
                  <= 0b0111'1111'1111'1111'1111'1111'1111'1111)  // 31bit ->
                                                                 // 6byte
       {
-        oss.put(
-            static_cast<uint8_t>(0b1111'1100 | (0b0000'0001 & (symbol >> 30))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 24))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 18))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 12))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 6))));
-        oss.put(
-            static_cast<uint8_t>(0b1000'0000 | (0b0011'1111 & (symbol >> 0))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1111'1100
+                                          | (0b0000'0001 & (symbol >> 30))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 24))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 18))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 12))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 6))));
+        oss.put(gsl::narrow_cast<uint8_t>(0b1000'0000
+                                          | (0b0011'1111 & (symbol >> 0))));
       }
     } else if (c == -1) {
       break;
     } else {
       iss.ignore();
-      oss.put(static_cast<uint8_t>(c));
+      oss.put(gsl::narrow_cast<uint8_t>(c));
     }
   }
 
@@ -243,7 +244,7 @@ std::string PercentEncoding::encode(const std::string &input) {
     if (c == -1) {
       break;
     }
-    if (need_encode(static_cast<uint8_t>(c))) {
+    if (need_encode(gsl::narrow_cast<uint8_t>(c))) {
       oss << '%' << std::uppercase << std::setfill('0') << std::setw(2)
           << std::hex << c;
     } else {

--- a/core/common/uri_parser/uri_parser.hpp
+++ b/core/common/uri_parser/uri_parser.hpp
@@ -32,103 +32,100 @@ namespace fc::common {
    public:
     enum class Scheme { UNDEFINED, HTTP, HTTPS };
 
-   private:
-    Scheme _scheme;
-    std::string _host;
-    uint16_t _port;
-    std::string _path;
-    bool _hasQuery;
-    std::string _query;
-    bool _hasFragment;
-    std::string _fragment;
-    mutable std::string _thisAsString;
+    HttpUri() = default;
 
-   public:
-    HttpUri();
-
-    HttpUri(const std::string &uri);
+    explicit HttpUri(const std::string &uri);
 
     virtual ~HttpUri() = default;
 
-    void parse(const char *string, size_t length);
-
-    void parse(const std::string &string) {
-      parse(string.c_str(), string.size());
-    };
+    void parse(const std::string &string);
 
     const std::string &str() const;
 
     Scheme scheme() const {
-      return _scheme;
+      return scheme_;
     }
 
     void setScheme(Scheme scheme) {
-      _scheme = scheme;
-      if (_port == 0) {
-        if (_scheme == Scheme::HTTP) {
-          _port = 80;
-        } else if (_scheme == Scheme::HTTPS) {
-          _port = 443;
+      scheme_ = scheme;
+      if (port_ == 0) {
+        if (scheme_ == Scheme::HTTP) {
+          port_ = 80;
+        } else if (scheme_ == Scheme::HTTPS) {
+          port_ = 443;
         }
       }
     }
 
     const std::string &host() const {
-      return _host;
+      return host_;
     }
 
     void setHost(const std::string &host) {
-      _host = host;
+      host_ = host;
     }
 
     uint16_t port() const {
-      return _port;
+      return port_;
     }
 
     void setPort(uint16_t port) {
-      _port = port;
+      port_ = port;
     }
 
     const std::string &path() const {
-      return _path;
+      return path_;
     }
 
     void setPath(const std::string &path) {
-      _path = path;
+      path_ = path;
     }
 
     bool hasQuery() const {
-      return _hasQuery;
+      return hasQuery_;
     }
 
     const std::string &query() const {
-      return _query;
+      return query_;
     }
 
     void setQuery(const std::string &query) {
-      _query = query;
-      if (!_query.empty()) {
-        _hasQuery = true;
+      query_ = query;
+      if (!query_.empty()) {
+        hasQuery_ = true;
       }
     }
 
     bool hasFragment() const {
-      return _hasFragment;
+      return hasFragment_;
     }
 
     const std::string &fragment() const {
-      return _fragment;
+      return fragment_;
     }
 
     void setFragment(const std::string &fragment) {
-      _fragment = fragment;
-      if (!_fragment.empty()) {
-        _hasFragment = true;
+      fragment_ = fragment;
+      if (!fragment_.empty()) {
+        hasFragment_ = true;
       }
     }
 
     static std::string urldecode(const std::string &input);
 
     static std::string urlencode(const std::string &input);
+
+   private:
+    void parsePath(const char *s, const char *end);
+
+    Scheme scheme_ = Scheme::UNDEFINED;
+    std::string host_;
+    uint16_t port_ = 0;
+    std::string path_;
+    bool hasQuery_ = false;
+    std::string query_;
+    bool hasFragment_ = false;
+    std::string fragment_;
+    mutable std::string thisAsString_;
   };
 }  // namespace fc::common

--- a/core/sector_storage/stores/index.hpp
+++ b/core/sector_storage/stores/index.hpp
@@ -86,7 +86,9 @@ namespace fc::sector_storage::stores {
         boost::optional<SectorSize> fetch_sector_size) = 0;
 
     virtual outcome::result<std::vector<StorageInfo>> storageBestAlloc(
-        const SectorFileType &allocate, SectorSize sector_size, bool sealing_mode) = 0;
+        const SectorFileType &allocate,
+        SectorSize sector_size,
+        bool sealing_mode) = 0;
 
     virtual outcome::result<std::shared_ptr<WLock>> storageLock(
         const SectorId &sector, SectorFileType read, SectorFileType write) = 0;


### PR DESCRIPTION
Signed-off-by: Alexey-N-Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
A few fixes for clang-tidy.

Found a useful `gsl::narrow_cast<uint8_t>` that must be used instead of `static_cast` for lose-data conversions.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
