### PR TITLE
fil-422 unsorted hamt

### DIFF
--- a/core/storage/hamt/hamt.hpp
+++ b/core/storage/hamt/hamt.hpp
@@ -57,7 +57,7 @@ namespace fc::storage::hamt {
   /** Hamt node representation */
   struct Node {
     using Ptr = std::shared_ptr<Node>;
-    using Leaf = std::map<Bytes, Bytes, BytesLess>;
+    using Leaf = std::vector<std::pair<Bytes, Bytes>>;
     using Item = boost::variant<CID, Ptr, Leaf>;
 
     std::map<size_t, Item> items;

--- a/test/core/test_vectors/test.cpp
+++ b/test/core/test_vectors/test.cpp
@@ -245,30 +245,6 @@ auto search() {
     const auto &path{item.path()};
     if (item.status().type() == boost::filesystem::file_type::regular_file
         && path.extension() == ".json") {
-      // Skip tests that fail in Fuhon
-      static std::vector<boost::filesystem::path> fail_in_fuhon{
-          // TODO (m.tagirov) FIL-422 test-vectors hamt have incorrect order
-          // Fuhon implementation loads and reorders hamt
-          // while Lotus implementation uses lazy approach and keeps initial incorrect order
-          kCorpusRoot / "extracted/0004-coverage-boost/fil_1_storagepower/CreateMiner/Ok/ext-0004-fil_1_storagepower-CreateMiner-Ok-6.json",
-          kCorpusRoot / "extracted/0004-coverage-boost/fil_1_storagepower/CreateMiner/Ok/ext-0004-fil_1_storagepower-CreateMiner-Ok-10.json",
-          kCorpusRoot / "extracted/0001-initial-extraction/fil_1_storagepower/CreateMiner/Ok/ext-0001-fil_1_storagepower-CreateMiner-Ok-6.json",
-          kCorpusRoot / "extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/Ok/ext-0001-fil_1_storageminer-PreCommitSector-Ok-1.json",
-          kCorpusRoot / "extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/Ok/ext-0001-fil_1_storageminer-PreCommitSector-Ok-5.json",
-          kCorpusRoot / "extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/Ok/ext-0001-fil_1_storageminer-PreCommitSector-Ok-6.json",
-          kCorpusRoot / "extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/Ok/ext-0001-fil_1_storageminer-PreCommitSector-Ok-8.json",
-          kCorpusRoot / "extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/Ok/ext-0001-fil_1_storageminer-PreCommitSector-Ok-9.json",
-          kCorpusRoot / "extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/Ok/ext-0004-fil_1_storageminer-PreCommitSector-Ok-4.json",
-          kCorpusRoot / "extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/Ok/ext-0004-fil_1_storageminer-PreCommitSector-Ok-5.json",
-          kCorpusRoot / "extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/Ok/ext-0004-fil_1_storageminer-PreCommitSector-Ok-7.json",
-          kCorpusRoot / "extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/Ok/ext-0004-fil_1_storageminer-PreCommitSector-Ok-9.json",
-      };
-
-      if (std::find(fail_in_fuhon.cbegin(), fail_in_fuhon.cend(), path)
-          != fail_in_fuhon.cend()) {
-        continue;
-      }
-
       // ignore broken/incorrect vectors that starts with "x--"
       if (boost::algorithm::starts_with(path.filename().string(), "x--")) {
         continue;


### PR DESCRIPTION
Fuhon implementation loads and reorders hamt, while Lotus implementation uses lazy approach and keeps initial incorrect order.