### PR TITLE
paych maker

### DIFF
--- a/core/api/impl/paych_get.hpp
+++ b/core/api/impl/paych_get.hpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "api/full_node/node_api.hpp"
+#include "payment_channel_manager/impl/maker.hpp"
+
+namespace fc::api {
+  inline void implPaychGet(
+      const std::shared_ptr<FullNodeApi> &api,
+      const std::shared_ptr<paych_maker::PaychMaker> &maker) {
+    api->PaychGet = [=](auto &&cb,
+                        const Address &from,
+                        const Address &to,
+                        const TokenAmount &amount) {
+      maker->make({from, to}, amount, std::move(cb));
+    };
+  }
+}  // namespace fc::api

--- a/core/node/main/builder.cpp
+++ b/core/node/main/builder.cpp
@@ -22,6 +22,7 @@
 #include <libp2p/protocol/kademlia/impl/validator_default.hpp>
 
 #include "api/full_node/make.hpp"
+#include "api/impl/paych_get.hpp"
 #include "api/setup_common.hpp"
 #include "blockchain/block_validator/impl/block_validator_impl.hpp"
 #include "blockchain/impl/weight_calculator_impl.hpp"
@@ -631,6 +632,11 @@ namespace fc::node {
                           o.market_discovery,
                           o.retrieval_market_client,
                           o.wallet_default_address);
+    api::implPaychGet(
+        o.api,
+        std::make_shared<paych_maker::PaychMaker>(
+            o.api,
+            std::make_shared<storage::MapPrefix>("paych_maker/", o.kv_store)));
 
     api::fillAuthApi(o.api, api_secret, log());
 

--- a/core/payment_channel_manager/CMakeLists.txt
+++ b/core/payment_channel_manager/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 
 add_library(payment_channel_manager
+    impl/maker.cpp
     impl/payment_channel_manager_impl.cpp
     impl/payment_channel_manager_error.cpp
     )

--- a/core/payment_channel_manager/impl/maker.cpp
+++ b/core/payment_channel_manager/impl/maker.cpp
@@ -1,0 +1,269 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "payment_channel_manager/impl/maker.hpp"
+
+#include "api/full_node/node_api.hpp"
+#include "common/outcome_fmt.hpp"
+#include "vm/actor/builtin/v0/init/init_actor.hpp"
+#include "vm/actor/builtin/v0/payment_channel/payment_channel_actor.hpp"
+#include "vm/toolchain/toolchain.hpp"
+
+namespace fc::paych_maker {
+  using vm::actor::builtin::v0::init::Exec;
+  using vm::message::UnsignedMessage;
+
+  inline auto &log() {
+    static auto log{common::createLogger("PaychMaker")};
+    return log;
+  }
+
+  inline UnsignedMessage msgCreate(const PaychMaker::It &it,
+                                   NetworkVersion network) {
+    using vm::actor::builtin::v0::payment_channel::Construct;
+    const auto &[from_to, queue]{*it};
+    return {
+        vm::actor::kInitAddress,
+        from_to.first,
+        {},
+        *queue.row.waiting_amount,
+        {},
+        {},
+        Exec::Number,
+        codec::cbor::encode(
+            Exec::Params{
+                vm::toolchain::Toolchain::createAddressMatcher(network)
+                    ->getPaymentChannelCodeId(),
+                codec::cbor::encode(Construct::Params{
+                                        from_to.first,
+                                        from_to.second,
+                                    })
+                    .value(),
+            })
+            .value(),
+    };
+  }
+
+  inline UnsignedMessage msgAdd(const PaychMaker::It &it) {
+    const auto &[from_to, queue]{*it};
+    return {
+        *queue.row.actor,
+        from_to.first,
+        {},
+        *queue.row.waiting_amount - queue.row.unused_amount,
+        {},
+        {},
+        vm::actor::kSendMethodNumber,
+        {},
+    };
+  }
+
+  inline void shift(Queue &queue) {
+    assert(!queue.row.waiting_cid);
+    assert(queue.waiting_cb.empty());
+    std::swap(queue.waiting_cb, queue.pending_cb);
+    queue.row.waiting_amount = std::move(queue.pending_amount);
+    queue.pending_amount = {};
+  }
+
+  Bytes Row::key(const FromTo &from_to) {
+    Bytes key;
+    append(key, encode(from_to.first));
+    append(key, encode(from_to.second));
+    return key;
+  }
+
+  void Queue::save() {
+    key.setCbor(row);
+  }
+
+  const CID &UnusedCid::get() {
+    if (!cid) {
+      cid = key.getCbor<CID>();
+    }
+    return *cid;
+  }
+
+  void UnusedCid::set(const CID &new_cid) {
+    cid = new_cid;
+    key.setCbor(new_cid);
+  }
+
+  PaychMaker::PaychMaker(const ApiPtr &api, const MapPtr &kv)
+      : api{api}, kv{kv}, unused_cid{{"unused_cid", kv}} {}
+
+  void PaychMaker::make(const FromTo &from_to,
+                        const TokenAmount &amount,
+                        Cb cb) {
+    std::unique_lock lock{mutex};
+    auto it{map.find(from_to)};
+    const auto empty{it == map.end()};
+    if (empty) {
+      it = map.emplace(from_to, Queue{{Row::key(from_to), kv}}).first;
+    }
+    auto &queue{it->second};
+    queue.pending_amount += amount;
+    queue.pending_cb.emplace_back(std::move(cb));
+    if (empty) {
+      if (queue.key.has()) {
+        queue.key.getCbor(queue.row);
+        if (const auto &cid{queue.row.waiting_cid}) {
+          lock.unlock();
+          api->StateWaitMsg([=](auto &&_wait) { onWait(it, std::move(_wait)); },
+                            *cid,
+                            kMessageConfidence,
+                            api::kLookbackNoLimit,
+                            true);
+          return;
+        }
+      } else {
+        lock.unlock();
+        api->StateNetworkVersion(
+            [=](auto &&_network) { onNetwork(it, _network); }, {});
+        return;
+      }
+    }
+    lock.unlock();
+    next(it);
+  }
+
+  void PaychMaker::onNetwork(It it, outcome::result<NetworkVersion> _network) {
+    std::unique_lock lock{mutex};
+    auto &queue{it->second};
+    assert(!queue.row.actor);
+    assert(!queue.row.waiting_cid);
+    if (!_network) {
+      log()->error("StateNetworkVersion {:#}", _network.error());
+      onError(it, _network.error());
+      return;
+    }
+    const auto &network{_network.value()};
+    shift(queue);
+    const auto msg{msgCreate(it, network)};
+    lock.unlock();
+    api->MpoolPushMessage([=](auto &&_smsg) { onPush(it, std::move(_smsg)); },
+                          msg,
+                          api::kPushNoSpec);
+  }
+
+  void PaychMaker::onPush(It it, outcome::result<SignedMessage> _smsg) {
+    std::unique_lock lock{mutex};
+    auto &queue{it->second};
+    assert(!queue.row.waiting_cid);
+    if (!_smsg) {
+      log()->error("MpoolPushMessage {:#}", _smsg.error());
+      queue.row.waiting_amount.reset();
+      queue.save();
+      onError(it, _smsg.error());
+      return;
+    }
+    const auto &smsg{_smsg.value()};
+    const auto cid{smsg.getCid()};
+    queue.row.waiting_cid = cid;
+    queue.save();
+    lock.unlock();
+    api->StateWaitMsg([=](auto &&_wait) { onWait(it, std::move(_wait)); },
+                      cid,
+                      kMessageConfidence,
+                      api::kLookbackNoLimit,
+                      true);
+  }
+
+  void PaychMaker::onWait(It it, outcome::result<MsgWait> _wait) {
+    std::unique_lock lock{mutex};
+    auto &queue{it->second};
+    const auto cid{*queue.row.waiting_cid};
+    if (!_wait) {
+      log()->error("StateWaitMsg {} {:#}", cid, _wait.error());
+      onError(it, _wait.error());
+      return;
+    }
+    const auto &wait{_wait.value()};
+    if (wait.receipt.exit_code != vm::VMExitCode::kOk) {
+      queue.row.waiting_amount.reset();
+      queue.row.waiting_cid.reset();
+      queue.save();
+      onError(it, wait.receipt.exit_code);
+      return;
+    }
+    if (!queue.row.actor) {
+      auto _result{
+          codec::cbor::decode<Exec::Result>(wait.receipt.return_value)};
+      if (!_result) {
+        log()->error("onWait result decode {}",
+                     common::hex_lower(wait.receipt.return_value));
+        onError(it, _result.error());
+        return;
+      }
+      const auto &result{_result.value()};
+      queue.row.actor = result.robust_address;
+    }
+    queue.row.total_amount += *queue.row.waiting_amount;
+    if (queue.waiting_cb.empty()) {
+      queue.row.unused_amount += *queue.row.waiting_amount;
+      log()->info("unused + {} = {}",
+                  *queue.row.waiting_amount,
+                  queue.row.unused_amount);
+    } else if (auto reused{std::min<TokenAmount>(queue.row.unused_amount,
+                                                 *queue.row.waiting_amount)}) {
+      queue.row.unused_amount -= reused;
+      log()->info("unused - {} = {}", reused, queue.row.unused_amount);
+    }
+    queue.row.waiting_amount.reset();
+    queue.row.waiting_cid.reset();
+    queue.save();
+    unused_cid.set(cid);
+    AddChannelInfo result{*queue.row.actor, cid};
+    for (const auto &cb : queue.waiting_cb) {
+      cb(result);
+    }
+    queue.waiting_cb.clear();
+    lock.unlock();
+    next(it);
+  }
+
+  void PaychMaker::next(It it) {
+    std::unique_lock lock{mutex};
+    auto &queue{it->second};
+    if (!queue.row.actor || queue.row.waiting_cid || queue.row.waiting_amount
+        || queue.pending_cb.empty()) {
+      return;
+    }
+    if (queue.row.unused_amount >= queue.pending_amount) {
+      queue.row.unused_amount -= queue.pending_amount;
+      queue.save();
+      log()->info(
+          "unused - {} = {}", queue.pending_amount, queue.row.unused_amount);
+      queue.pending_amount = {};
+      AddChannelInfo result{*queue.row.actor, unused_cid.get()};
+      for (const auto &cb : queue.pending_cb) {
+        cb(result);
+      }
+      queue.pending_cb.clear();
+      return;
+    }
+    shift(queue);
+    queue.save();
+    const auto msg{msgAdd(it)};
+    lock.unlock();
+    api->MpoolPushMessage([=](auto &&_smsg) { onPush(it, std::move(_smsg)); },
+                          msg,
+                          api::kPushNoSpec);
+  }
+
+  void PaychMaker::onError(It it, std::error_code ec) {
+    auto &queue{it->second};
+    for (const auto &cb : queue.waiting_cb) {
+      cb(ec);
+    }
+    queue.waiting_cb.clear();
+    queue.pending_amount = {};
+    for (const auto &cb : queue.pending_cb) {
+      cb(ec);
+    }
+    queue.pending_cb.clear();
+    map.erase(it);
+  }
+}  // namespace fc::paych_maker

--- a/core/payment_channel_manager/impl/maker.hpp
+++ b/core/payment_channel_manager/impl/maker.hpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "fwd.hpp"
+#include "primitives/address/address.hpp"
+#include "primitives/cid/cid.hpp"
+#include "storage/leveldb/prefix.hpp"
+#include "vm/version/version.hpp"
+
+#include <mutex>
+
+namespace fc::api {
+  struct MsgWait;
+  struct AddChannelInfo;
+}  // namespace fc::api
+
+namespace fc::paych_maker {
+  using ApiPtr = std::shared_ptr<api::FullNodeApi>;
+  using api::AddChannelInfo;
+  using api::MsgWait;
+  using primitives::TokenAmount;
+  using primitives::address::Address;
+  using storage::MapPtr;
+  using storage::OneKey;
+  using vm::message::SignedMessage;
+  using vm::version::NetworkVersion;
+
+  using FromTo = std::pair<Address, Address>;
+
+  using Cb = std::function<void(outcome::result<AddChannelInfo>)>;
+
+  struct Row {
+    static Bytes key(const FromTo &from_to);
+
+    boost::optional<Address> actor;
+    TokenAmount total_amount;
+    TokenAmount unused_amount;
+    boost::optional<CID> waiting_cid;
+    boost::optional<TokenAmount> waiting_amount;
+  };
+  CBOR_TUPLE(
+      Row, actor, total_amount, unused_amount, waiting_cid, waiting_amount)
+
+  struct Queue {
+    using Map = std::map<FromTo, Queue>;
+
+    void save();
+
+    OneKey key;
+    Row row{};
+    std::vector<Cb> waiting_cb{};
+    TokenAmount pending_amount{};
+    std::vector<Cb> pending_cb{};
+  };
+
+  struct UnusedCid {
+    const CID &get();
+    void set(const CID &new_cid);
+
+    OneKey key;
+    boost::optional<CID> cid{};
+  };
+
+  struct PaychMaker {
+    using It = Queue::Map::iterator;
+
+    PaychMaker(const ApiPtr &api, const MapPtr &kv);
+
+    void make(const FromTo &from_to, const TokenAmount &amount, Cb cb);
+
+    void onNetwork(It it, outcome::result<NetworkVersion> _network);
+    void onPush(It it, outcome::result<SignedMessage> _smsg);
+    void onWait(It it, outcome::result<MsgWait> _wait);
+    void onError(It it, std::error_code ec);
+    void next(It it);
+
+    ApiPtr api;
+    MapPtr kv;
+    UnusedCid unused_cid;
+    std::mutex mutex;
+    Queue::Map map;
+  };
+}  // namespace fc::paych_maker

--- a/core/payment_channel_manager/impl/payment_channel_manager_impl.hpp
+++ b/core/payment_channel_manager/impl/payment_channel_manager_impl.hpp
@@ -34,11 +34,6 @@ namespace fc::payment_channel_manager {
     PaymentChannelManagerImpl(std::shared_ptr<FullNodeApi> api,
                               std::shared_ptr<Ipld> ipld);
 
-    void getOrCreatePaymentChannel(const Address &client,
-                                   const Address &miner,
-                                   const TokenAmount &amount_available,
-                                   AddChannelInfoCb cb) override;
-
     outcome::result<LaneId> allocateLane(const Address &channel) override;
 
     outcome::result<SignedVoucher> createPaymentVoucher(
@@ -53,9 +48,6 @@ namespace fc::payment_channel_manager {
         const Address &channel_address,
         const SignedVoucher &voucher) const override;
 
-    boost::optional<Address> findChannel(const Address &control,
-                                         const Address &target) const override;
-
     void makeApi(FullNodeApi &api) override;
 
    private:
@@ -68,21 +60,6 @@ namespace fc::payment_channel_manager {
     void saveChannel(const Address &channel_actor_address,
                      const Address &control,
                      const Address &target);
-
-    /**
-     * Sends funds
-     * @param to address
-     * @param from address
-     * @param amount to send
-     * @return CID add funds message
-     */
-    outcome::result<CID> addFunds(const Address &to,
-                                  const Address &from,
-                                  const TokenAmount &amount);
-
-    outcome::result<CID> createPaymentChannelActor(const Address &to,
-                                                   const Address &from,
-                                                   const TokenAmount &amount);
 
     /**
      * Loads payment channel actor state

--- a/core/payment_channel_manager/payment_channel_manager.hpp
+++ b/core/payment_channel_manager/payment_channel_manager.hpp
@@ -27,22 +27,6 @@ namespace fc::payment_channel_manager {
    public:
     virtual ~PaymentChannelManager() = default;
 
-    using AddChannelInfoCb =
-        std::function<void(outcome::result<AddChannelInfo>)>;
-    /**
-     * Sets up a new payment channel if one does not exist between a client and
-     * a miner and ensures the client has the given amount of funds available in
-     * the channel
-     * @param client address
-     * @param miner address
-     * @return payment channel address and funding or channel creation message
-     * CID
-     */
-    virtual void getOrCreatePaymentChannel(const Address &client,
-                                           const Address &miner,
-                                           const TokenAmount &amount_available,
-                                           AddChannelInfoCb cb) = 0;
-
     /**
      * Allocate late creates a lane within a payment channel so that calls to
      * CreatePaymentVoucher will automatically make vouchers only for the
@@ -82,15 +66,6 @@ namespace fc::payment_channel_manager {
      */
     virtual outcome::result<void> validateVoucher(
         const Address &channel_address, const SignedVoucher &voucher) const = 0;
-
-    /**
-     * Looks for channel in local offchain storage by addresses
-     * @param control address
-     * @param target address
-     * @return payment channel actor address
-     */
-    virtual boost::optional<Address> findChannel(
-        const Address &control, const Address &target) const = 0;
 
     /**
      * Adds payment channel manager methods to API

--- a/core/storage/chain/msg_waiter.cpp
+++ b/core/storage/chain/msg_waiter.cpp
@@ -185,7 +185,7 @@ namespace fc::storage::blockchain {
       const auto confidence{head->height() - wait.ts->height()};
       for (auto it2{wait.callbacks.begin()}; it2 != wait.callbacks.end();) {
         if (confidence >= it2->first) {
-          it2->second(wait.ts, wait.receipt);
+          io->post(std::bind(std::move(it2->second), wait.ts, wait.receipt));
           it2 = wait.callbacks.erase(it2);
         } else {
           ++it2;

--- a/core/storage/leveldb/prefix.cpp
+++ b/core/storage/leveldb/prefix.cpp
@@ -128,8 +128,8 @@ namespace fc::storage {
     return std::make_unique<Cursor>(*this, map->cursor());
   }
 
-  OneKey::OneKey(BytesIn key, MapPtr map)
-      : key{copy(key)}, map{std::move(map)} {}
+  OneKey::OneKey(BytesCow &&key, MapPtr map)
+      : key{key.into()}, map{std::move(map)} {}
 
   OneKey::OneKey(std::string_view key, MapPtr map)
       : OneKey{common::span::cbytes(key), std::move(map)} {}

--- a/core/storage/leveldb/prefix.hpp
+++ b/core/storage/leveldb/prefix.hpp
@@ -57,7 +57,7 @@ namespace fc::storage {
   };
 
   struct OneKey {
-    OneKey(BytesIn key, MapPtr map);
+    OneKey(BytesCow &&key, MapPtr map);
     OneKey(std::string_view key, MapPtr map);
     bool has() const;
     Bytes get() const;


### PR DESCRIPTION
- extract `PaychGet` from `PaymentChannelManager` into `PaychMaker`.
- prevent duplicate channels with same from-to.
- batch pending `PaychGet` to single message.
- sending one message at a time and waiting before sending next.
- save relevant info to db.
- fix `StateWaitMsg` lock.

- may rename, e.g. ~router.