### PR TITLE
fix use after free in index_lock

### DIFF
--- a/core/sector_storage/stores/impl/index_lock.cpp
+++ b/core/sector_storage/stores/impl/index_lock.cpp
@@ -66,9 +66,10 @@ namespace fc::sector_storage::stores {
     }
     sector.write = static_cast<SectorFileType>(sector.write & ~lock.write);
     --sector.refs;
+    sector.cv.notify_all();
+    sector_lock.unlock();
     if (!sector.refs) {
       sectors.erase(lock.sector);
     }
-    sector.cv.notify_all();
   }
 }  // namespace fc::sector_storage::stores


### PR DESCRIPTION
Signed-off-by: Alexey Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Fix use after free in index lock.
`sectors.erase(lock.sector);` deletes sector and then `sector.cv` is accessed and `sector_lock` still holds `sector.mutex`.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
