### PR TITLE
CMake: Improve building without hunter

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -46,7 +46,12 @@ find_package(Boost.DI CONFIG REQUIRED)
 
 # https://docs.hunter.sh/en/latest/packages/pkg/leveldb.html
 hunter_add_package(leveldb)
-find_package(leveldb CONFIG REQUIRED)
+if (HUNTER_ENABLED)
+  find_package(leveldb CONFIG REQUIRED)
+else()
+  find_package(leveldb REQUIRED)
+  include_directories(${LEVELDB_INCLUDE_DIRS})
+endif()
 
 # https://github.com/soramitsu/libp2p
 hunter_add_package(libp2p)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,6 +1,11 @@
 # hunter dependencies
 # https://docs.hunter.sh/en/latest/packages/
 
+# Append local modules path if Hunter is not enabled
+if (NOT HUNTER_ENABLED)
+  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+endif()
+
 if (TESTING)
   # https://docs.hunter.sh/en/latest/packages/pkg/GTest.html
   hunter_add_package(GTest)
@@ -58,7 +63,12 @@ find_package(fmt CONFIG REQUIRED)
 
 # https://docs.hunter.sh/en/latest/packages/pkg/cppcodec.html
 hunter_add_package(cppcodec)
-find_package(cppcodec CONFIG REQUIRED)
+if (HUNTER_ENABLED)
+  find_package(cppcodec CONFIG REQUIRED)
+else()
+  find_package(cppcodec REQUIRED)
+  include_directories(${CPPCODEC_INCLUDE_DIRS})
+endif()
 
 # http://rapidjson.org
 hunter_add_package(RapidJSON)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -88,3 +88,9 @@ find_package(libarchive CONFIG REQUIRED)
 
 hunter_add_package(prometheus-cpp)
 find_package(prometheus-cpp CONFIG REQUIRED)
+
+# Add filecoin_ffi target if building without git submodules
+if (NOT BUILD_INTERNAL_DEPS)
+  find_package(filecoin_ffi REQUIRED)
+  include_directories(${FILECOIN_FFI_INCLUDE_DIRS})
+endif()

--- a/cmake/modules/Findcppcodec.cmake
+++ b/cmake/modules/Findcppcodec.cmake
@@ -1,0 +1,20 @@
+#.rst:
+# Findcppcodec.cmake
+# ------------------
+# Try to find cppcodec
+#
+# This will define the following variables:
+#
+# CPPCODEC_FOUND - system has cppcodec
+# CPPCODEC_INCLUDE_DIRS - cppcodec include directories
+#
+
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_CPPCODEC cppcodec)
+endif()
+
+if (PC_CPPCODEC_FOUND)
+  set(CPPCODEC_FOUND "${PC_CPPCODEC_FOUND}")
+  set(CPPCODEC_INCLUDE_DIRS "${PC_CPPCODEC_INCLUDEDIR}")
+endif()

--- a/cmake/modules/Findfilecoin_ffi.cmake
+++ b/cmake/modules/Findfilecoin_ffi.cmake
@@ -1,0 +1,57 @@
+#.rst:
+# Findfilecoin_ffi.cmake
+# -----------
+# Finds the Filecoin FFI library
+#
+# This will define the following variables:
+#
+#   FILECOIN_FFI_FOUND        -  system has filecoin_ffi
+#   FILECOIN_FFI_INCLUDE_DIRS -  filecoin_ffi include directories
+#   FILECOIN_FFI_LIBRARY      -  library needed to use filecoin_ffi
+#
+# and the following imported targets:
+#
+#   filecoin_ffi   - The filecoin_ffi library
+#
+
+find_package(PkgConfig REQUIRED)
+
+find_path(FILECOIN_FFI_INCLUDE_DIR
+  NAMES filecoin-ffi/filcrypto.h
+  HINTS "${FILECOIN_FFI_ROOT_DIR}" "$ENV{FILECOIN_FFI_ROOT_DIR}"
+  PATH_SUFFIXES include
+)
+
+find_library(FILECOIN_FFI_LIBRARY
+  NAMES filcrypto
+  HINTS "${FILECOIN_FFI_ROOT_DIR}" "$ENV{FILECOIN_FFI_ROOT_DIR}"
+  PATH_SUFFIXES "${LIBRARY_PATH_PREFIX}"
+)
+message(FALAL_ERROR "${LIBRARY_PATH_PREFIX}")
+
+pkg_check_modules(PKG_FILECOIN IMPORTED_TARGET filcrypto)
+
+if (PKG_FILECOIN_FOUND)
+  set(FILECOIN_FFI_FOUND "${PKG_FILECOIN_FOUND}")
+  set(FILECOIN_FFI_INCLUDE_DIRS "${FILECOIN_FFI_INCLUDE_DIR}")
+  set(FILECOIN_FFI_LIBRARIES "${FILECOIN_FFI_LIBRARY}")
+
+  add_library(filecoin_ffi
+    STATIC
+    IMPORTED
+    GLOBAL
+  )
+
+  set_target_properties(filecoin_ffi
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${FILECOIN_FFI_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${FILECOIN_FFI_LIBRARY}"
+  )
+
+  target_link_libraries(filecoin_ffi
+    INTERFACE PkgConfig::PKG_FILECOIN
+  )
+endif()
+
+mark_as_advanced(FILECOIN_FFI_INCLUDE_DIR)
+mark_as_advanced(FILECOIN_FFI_LIBRARY)

--- a/cmake/modules/Findleveldb.cmake
+++ b/cmake/modules/Findleveldb.cmake
@@ -1,0 +1,54 @@
+#.rst:
+# Findleveldb.cmake
+# -----------
+# Finds the leveldb library
+#
+# This will define the following variables:
+#
+#   LEVELDB_FOUND        -  system has leveldb
+#   LEVELDB_INCLUDE_DIRS -  leveldb include directories
+#   LEVELDB_LIBRARIES    -  libraries needed to use leveldb
+#
+# and the following imported targets:
+#
+#   leveldb::leveldb   - The leveldb library
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_path(
+  LEVELDB_INCLUDE_DIR
+  NAMES leveldb/db.h
+  HINTS "${LEVELDB_ROOT_DIR}" "$ENV{LEVELDB_ROOT_DIR}"
+  PATH_SUFFIXES include
+)
+
+find_library(
+  LEVELDB_LIBRARY
+  NAMES leveldb
+  HINTS "${LEVELDB_ROOT_DIR}" "$ENV{LEVELDB_ROOT_DIR}"
+  PATH_SUFFIXES "${LIBRARY_PATH_PREFIX}"
+)
+
+find_package_handle_standard_args(
+  leveldb
+  DEFAULT_MSG
+    LEVELDB_INCLUDE_DIR
+    LEVELDB_LIBRARY
+)
+
+if (LEVELDB_FOUND)
+  set(LEVELDB_INCLUDE_DIRS "${LEVELDB_INCLUDE_DIR}")
+  set(LEVELDB_LIBRARIES "${LEVELDB_LIBRARY}")
+
+  if (NOT TARGET leveldb::leveldb)
+    add_library(leveldb::leveldb UNKNOWN IMPORTED)
+    set_target_properties(leveldb::leveldb PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LEVELDB_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${LEVELDB_LIBRARY}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(LEVELDB_INCLUDE_DIR)
+mark_as_advanced(LEVELDB_LIBRARY)


### PR DESCRIPTION
### Description of the Change

Now that https://github.com/filecoin-project/cpp-filecoin/pull/128 is merged, I've got Fuhon building without hunter again.

The approach is to delegate finding dependencies to the build system using the typical CMake approach, using find modules. I've included three find modules in this PR.

I only included find modules for three of the dependencies. The reason is because downstream, I just use the hunterized versions of dependencies. However, the hunter team made the unfortunate but easy choice of forking repos. This means that many dependencies have fallen behind the versions used by my team's app. We can't downgrade three of the packages, so I wrote CMake find modules for these three dependencies.

The final patch, for filecoin_ffi, also means that git submodules are no longer needed. This is advantageous, because git submodules cause problems for a fair number of build systems and packagers. And who hasn't forgotten `--recursive`.

It's an open question if we want CMake find modules for any additional dependencies. I could possibly add this to my List Of Things To Do (tm).

### Benefits

* Improved building of Fuhon in environments without Hunter.

### Possible Drawbacks 

CMake code is added, currently totaling about 70 lines. Normally any lines added increases the load of maintenance, but code that doesn't ship has much less of an impact.

### Alternate Designs *[optional]*

I currently use an alternative approach for the Curl dependency - I just patch out the `CONFIG` parameter, and ship the patch with the rest of my work. The exact patch is:

```
commit a136981cfaf04e7fe7f8ced38bcd9ebaf6493f91
Author: Garrett Brown <eigendebugger@gmail.com>
Date:   Tue Feb 15 10:18:31 2022 -0800

    [temp] CMake: Delegate finding CURL to the build system

diff --git a/cmake/dependencies.cmake b/cmake/dependencies.cmake
index 6c5636dd..de953113 100644
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -25,8 +25,7 @@ hunter_add_package(OpenSSL)
 find_package(OpenSSL REQUIRED)
 
 # https://hunter.readthedocs.io/en/latest/packages/pkg/CURL.html#pkg-curl
-hunter_add_package(CURL)
-find_package(CURL CONFIG REQUIRED)
+find_package(CURL REQUIRED)
 
 # https://developers.google.com/protocol-buffers/
 hunter_add_package(Protobuf)
```

By not including Curl in this PR, it increases my downstream technical debt, but not significantly.