### PR TITLE
cli base

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_subdirectory(adt)
 add_subdirectory(api)
 add_subdirectory(blockchain)
+add_subdirectory(cli)
 add_subdirectory(clock)
 add_subdirectory(codec)
 add_subdirectory(common)

--- a/core/api/rpc/info.hpp
+++ b/core/api/rpc/info.hpp
@@ -23,13 +23,18 @@ namespace fc::api::rpc {
       std::string_view info{_info};
       auto i{info.find(":")};
       if (i == info.npos) {
+        address = info;
+      } else {
+        token = info.substr(0, i);
+        address = info.substr(i + 1);
+      }
+    } else if (!repo.empty()) {
+      try {
+        boost::filesystem::load_string_file(repo / "api", address);
+        boost::filesystem::load_string_file(repo / "token", token);
+      } catch (...) {
         return {};
       }
-      address = info.substr(0, i);
-      token = info.substr(i + 1);
-    } else if (!repo.empty()) {
-      boost::filesystem::load_string_file(repo / "api", address);
-      boost::filesystem::load_string_file(repo / "token", token);
     } else {
       return {};
     }

--- a/core/cli/CMakeLists.txt
+++ b/core/cli/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_library(cli INTERFACE)
+target_link_libraries(cli INTERFACE
+    Boost::program_options
+    fmt::fmt
+    )
+
+add_subdirectory(node)

--- a/core/cli/cli.hpp
+++ b/core/cli/cli.hpp
@@ -1,0 +1,139 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <map>
+#include <memory>
+#include <typeindex>
+
+#include "cli/try.hpp"
+
+#define CLI_BOOL(NAME, DESCRIPTION)                               \
+  struct {                                                        \
+    bool _{};                                                     \
+    void operator()(Opts &opts) {                                 \
+      opts.add_options()(NAME, po::bool_switch(&_), DESCRIPTION); \
+    }                                                             \
+    operator bool() const {                                       \
+      return _;                                                   \
+    }                                                             \
+  }
+
+#define CLI_DEFAULT(NAME, DESCRIPTION, TYPE, INIT)          \
+  struct {                                                  \
+    TYPE _ INIT;                                            \
+    void operator()(Opts &opts) {                           \
+      opts.add_options()(NAME, po::value(&_), DESCRIPTION); \
+    }                                                       \
+    auto &operator*() const {                               \
+      return _;                                             \
+    }                                                       \
+    auto &operator*() {                                     \
+      return _;                                             \
+    }                                                       \
+    auto *operator->() const {                              \
+      return &_;                                            \
+    }                                                       \
+    auto *operator->() {                                    \
+      return &_;                                            \
+    }                                                       \
+  }
+
+#define CLI_OPTIONAL(NAME, DESCRIPTION, TYPE)                              \
+  struct {                                                                 \
+    boost::optional<TYPE> _;                                               \
+    void operator()(Opts &opts) {                                          \
+      opts.add_options()(NAME, po::value(&_), DESCRIPTION);                \
+    }                                                                      \
+    operator bool() const {                                                \
+      return _.operator bool();                                            \
+    }                                                                      \
+    void check() const {                                                   \
+      if (!_) {                                                            \
+        throw ::fc::cli::CliError{"--{} argument is required but missing", \
+                                  NAME};                                   \
+      }                                                                    \
+    }                                                                      \
+    auto &operator*() const {                                              \
+      check();                                                             \
+      return *_;                                                           \
+    }                                                                      \
+    auto &operator*() {                                                    \
+      check();                                                             \
+      return *_;                                                           \
+    }                                                                      \
+    auto *operator->() const {                                             \
+      return &**this;                                                      \
+    }                                                                      \
+    auto *operator->() {                                                   \
+      return &**this;                                                      \
+    }                                                                      \
+  }
+
+#define CLI_OPTS() ::fc::cli::Opts opts()
+#define CLI_RUN()                  \
+  static ::fc::cli::RunResult run( \
+      ::fc::cli::ArgsMap &argm, Args &args, ::fc::cli::Argv &&argv)
+#define CLI_NO_RUN() constexpr static std::nullptr_t run{nullptr};
+
+namespace fc::cli {
+  namespace po = boost::program_options;
+  using Opts = po::options_description;
+
+  using RunResult = void;
+  struct ArgsMap {
+    std::map<std::type_index, std::shared_ptr<void>> _;
+    template <typename Args>
+    void add(Args &&v) {
+      _.emplace(typeid(Args), std::make_shared<Args>(std::forward<Args>(v)));
+    }
+    template <typename Cmd>
+    typename Cmd::Args &of() {
+      return *reinterpret_cast<typename Cmd::Args *>(
+          _.at(typeid(typename Cmd::Args)).get());
+    }
+  };
+  // note: Args is defined inside command
+  using Argv = std::vector<std::string>;
+
+  const std::string &cliArgv(const Argv &argv,
+                             size_t i,
+                             const std::string_view &name) {
+    if (i < argv.size()) {
+      return argv[i];
+    }
+    throw CliError{"positional argument {} is required but missing", name};
+  }
+  template <typename T>
+  T cliArgv(const std::string &arg, const std::string_view &name) {
+    boost::any out;
+    try {
+      po::value<T>()->xparse(out, Argv{arg});
+    } catch (po::validation_error &e) {
+      e.set_option_name(std::string{name});
+      throw;
+    }
+    return boost::any_cast<T>(out);
+  }
+  template <typename T>
+  T cliArgv(const Argv &argv, size_t i, const std::string_view &name) {
+    return cliArgv<T>(cliArgv(argv, i, name), name);
+  }
+
+  struct Empty {
+    struct Args {
+      CLI_OPTS() {
+        return {};
+      }
+    };
+    CLI_NO_RUN();
+  };
+  using Group = Empty;
+
+  struct ShowHelp {};
+}  // namespace fc::cli

--- a/core/cli/cli.hpp
+++ b/core/cli/cli.hpp
@@ -15,57 +15,57 @@
 
 #define CLI_BOOL(NAME, DESCRIPTION)                               \
   struct {                                                        \
-    bool _{};                                                     \
+    bool v{};                                                     \
     void operator()(Opts &opts) {                                 \
-      opts.add_options()(NAME, po::bool_switch(&_), DESCRIPTION); \
+      opts.add_options()(NAME, po::bool_switch(&v), DESCRIPTION); \
     }                                                             \
     operator bool() const {                                       \
-      return _;                                                   \
+      return v;                                                   \
     }                                                             \
   }
 
 #define CLI_DEFAULT(NAME, DESCRIPTION, TYPE, INIT)          \
   struct {                                                  \
-    TYPE _ INIT;                                            \
+    TYPE v INIT;                                            \
     void operator()(Opts &opts) {                           \
-      opts.add_options()(NAME, po::value(&_), DESCRIPTION); \
+      opts.add_options()(NAME, po::value(&v), DESCRIPTION); \
     }                                                       \
     auto &operator*() const {                               \
-      return _;                                             \
+      return v;                                             \
     }                                                       \
     auto &operator*() {                                     \
-      return _;                                             \
+      return v;                                             \
     }                                                       \
     auto *operator->() const {                              \
-      return &_;                                            \
+      return &v;                                            \
     }                                                       \
     auto *operator->() {                                    \
-      return &_;                                            \
+      return &v;                                            \
     }                                                       \
   }
 
 #define CLI_OPTIONAL(NAME, DESCRIPTION, TYPE)                              \
   struct {                                                                 \
-    boost::optional<TYPE> _;                                               \
+    boost::optional<TYPE> v;                                               \
     void operator()(Opts &opts) {                                          \
-      opts.add_options()(NAME, po::value(&_), DESCRIPTION);                \
+      opts.add_options()(NAME, po::value(&v), DESCRIPTION);                \
     }                                                                      \
     operator bool() const {                                                \
-      return _.operator bool();                                            \
+      return v.operator bool();                                            \
     }                                                                      \
     void check() const {                                                   \
-      if (!_) {                                                            \
+      if (!v) {                                                            \
         throw ::fc::cli::CliError{"--{} argument is required but missing", \
                                   NAME};                                   \
       }                                                                    \
     }                                                                      \
     auto &operator*() const {                                              \
       check();                                                             \
-      return *_;                                                           \
+      return *v;                                                           \
     }                                                                      \
     auto &operator*() {                                                    \
       check();                                                             \
-      return *_;                                                           \
+      return *v;                                                           \
     }                                                                      \
     auto *operator->() const {                                             \
       return &**this;                                                      \

--- a/core/cli/node/CMakeLists.txt
+++ b/core/cli/node/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_executable(fuhon-node-cli
+    main.cpp
+    )
+target_link_libraries(fuhon-node-cli
+    cli
+    rpc
+    )
+set_target_properties(fuhon-node-cli PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )

--- a/core/cli/node/main.cpp
+++ b/core/cli/node/main.cpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cli/node/net.hpp"
+#include "cli/run.hpp"
+
+#define CMD(NAME, TYPE) \
+  { NAME, tree<TYPE>() }
+#define CMDS(NAME, TYPE) NAME, tree<TYPE>
+#define GROUP(NAME) CMDS(NAME, Group)
+
+namespace fc::cli::_node {
+  const auto _tree{tree<Node>({
+      {GROUP("net")({
+          CMD("connect", Node_net_connect),
+          CMD("listen", Node_net_listen),
+          CMD("peers", Node_net_peers),
+      })},
+      CMD("version", Node_version),
+  })};
+}  // namespace fc::cli::_node
+
+int main(int argc, const char *argv[]) {
+  fc::cli::run("fuhon-node-cli", fc::cli::_node::_tree, argc, argv);
+}

--- a/core/cli/node/net.hpp
+++ b/core/cli/node/net.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "cli/node/node.hpp"
+
+namespace fc::cli::_node {
+  inline void printPeer(const PeerInfo &peer) {
+    for (const auto &addr : peer.addresses) {
+      fmt::print("{}/p2p/{}\n", addr.getStringAddress(), peer.id.toBase58());
+    }
+  }
+
+  struct Node_net_connect : Empty {
+    CLI_RUN() {
+      Node::Api api{argm};
+      for (const auto &arg : argv) {
+        const auto peer{cliArgv<PeerInfo>(arg, "peer")};
+        cliTry(api->NetConnect(peer));
+      }
+    }
+  };
+
+  struct Node_net_listen : Empty {
+    CLI_RUN() {
+      Node::Api api{argm};
+      const auto peer{cliTry(api->NetAddrsListen())};
+      printPeer(peer);
+    }
+  };
+
+  struct Node_net_peers : Empty {
+    CLI_RUN() {
+      Node::Api api{argm};
+      const auto peers{cliTry(api->NetPeers())};
+      for (const auto &peer : peers) {
+        printPeer(peer);
+      }
+    }
+  };
+}  // namespace fc::cli::_node

--- a/core/cli/node/node.hpp
+++ b/core/cli/node/node.hpp
@@ -37,25 +37,28 @@ namespace fc::cli::_node {
     }
 
     struct Api {
-      std::shared_ptr<api::FullNodeApi> _;
+     private:
       IoThread thread;
       std::shared_ptr<api::rpc::Client> wsc;
+
+     public:
+      std::shared_ptr<api::FullNodeApi> api;
 
       Api(ArgsMap &argm) {
         const auto &args{argm.of<Node>()};
         const auto info{
             cliTry(api::rpc::loadInfo(*args.repo, "FULLNODE_API_INFO").o,
                    "api info is missing")};
-        _ = std::make_shared<api::FullNodeApi>();
+        api = std::make_shared<api::FullNodeApi>();
         wsc = std::make_shared<api::rpc::Client>(*thread.io);
-        wsc->setup(*_);
+        wsc->setup(*api);
         cliTry(wsc->connect(info.first, "/rpc/v1", info.second),
                "connecting to {}",
                info.first);
       }
 
       auto *operator->() const {
-        return _.operator->();
+        return api.operator->();
       }
     };
   };

--- a/core/cli/node/node.hpp
+++ b/core/cli/node/node.hpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "api/rpc/client_setup.hpp"
+#include "api/rpc/info.hpp"
+#include "cli/cli.hpp"
+#include "cli/validate/peer_info.hpp"
+#include "common/git_commit_version/git_commit_version.hpp"
+#include "common/libp2p/multi/multiaddress_fmt.hpp"
+
+namespace fc::cli::_node {
+  using libp2p::peer::PeerInfo;
+
+  struct Node {
+    struct Args {
+      CLI_BOOL("version", "") version;
+      CLI_DEFAULT("repo", "", boost::filesystem::path, ) repo;
+
+      CLI_OPTS() {
+        Opts opts;
+        version(opts);
+        repo(opts);
+        return opts;
+      }
+    };
+    CLI_RUN() {
+      if (args.version) {
+        fmt::print("fuhon-node-cli {}\n",
+                   common::git_commit_version::getGitPrettyVersion());
+        return;
+      }
+      throw ShowHelp{};
+    }
+
+    struct Api {
+      std::shared_ptr<api::FullNodeApi> _;
+      IoThread thread;
+      std::shared_ptr<api::rpc::Client> wsc;
+
+      Api(ArgsMap &argm) {
+        const auto &args{argm.of<Node>()};
+        const auto info{
+            cliTry(api::rpc::loadInfo(*args.repo, "FULLNODE_API_INFO").o,
+                   "api info is missing")};
+        _ = std::make_shared<api::FullNodeApi>();
+        wsc = std::make_shared<api::rpc::Client>(*thread.io);
+        wsc->setup(*_);
+        cliTry(wsc->connect(info.first, "/rpc/v1", info.second),
+               "connecting to {}",
+               info.first);
+      }
+
+      auto *operator->() const {
+        return _.operator->();
+      }
+    };
+  };
+
+  struct Node_version : Empty {
+    CLI_RUN() {
+      Node::Api api{argm};
+      const auto version{cliTry(api->Version())};
+      fmt::print("Version: {}\n", version.version);
+    }
+  };
+}  // namespace fc::cli::_node

--- a/core/cli/run.hpp
+++ b/core/cli/run.hpp
@@ -1,0 +1,116 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/variables_map.hpp>
+
+#include "cli/tree.hpp"
+
+namespace fc::cli {
+  inline bool isDash(const std::string &s) {
+    return !s.empty() && s[0] == '-';
+  }
+  inline bool isDashDash(const std::string &s) {
+    return s.size() == 2 && s[0] == '-' && s[1] == '-';
+  }
+  // note: returns first positional arg or end
+  inline Argv::iterator boostWorkaround(po::variables_map &vm,
+                                        const Opts &opts,
+                                        Argv::iterator begin,
+                                        Argv::iterator end) {
+    po::parsed_options parsed{&opts};
+    while (true) {
+      if (begin == end) {
+        break;
+      }
+      if (!isDash(*begin)) {
+        break;
+      }
+      if (isDashDash(*begin)) {
+        ++begin;
+        break;
+      }
+      const auto it{std::find_if(begin + 1, end, isDash)};
+      const auto options{
+          po::command_line_parser{Argv{begin, it}}.options(opts).run().options};
+      if (options.empty()) {
+        break;
+      }
+      for (const auto &option : options) {
+        parsed.options.emplace_back(option);
+        if (option.string_key.empty()) {
+          break;
+        }
+        begin += option.original_tokens.size();
+      }
+    }
+    po::store(parsed, vm);
+    return begin;
+  }
+
+  inline RunResult run(std::string app, const Tree &_tree, Argv argv) {
+    auto tree{&_tree};
+    std::vector<std::string> cmds;
+    cmds.emplace_back(std::move(app));
+    ArgsMap argm;
+    auto argv_it{argv.begin()};
+    while (true) {
+      auto args{tree->args()};
+      auto option{args.opts.add_options()};
+      option("help,h", "print help");
+      po::variables_map vm;
+      try {
+        argv_it = boostWorkaround(vm, args.opts, argv_it, argv.end());
+      } catch (po::error &e) {
+        fmt::print("{}: {}\n", fmt::join(cmds, " "), e.what());
+        return;
+      }
+      const auto help{vm.count("help") != 0};
+      if (!help) {
+        po::notify(vm);
+        argm._.emplace(args._);
+        if (argv_it != argv.end()) {
+          auto sub_it{tree->sub.find(*argv_it)};
+          if (sub_it != tree->sub.end()) {
+            ++argv_it;
+            cmds.emplace_back(sub_it->first);
+            tree = &sub_it->second;
+            continue;
+          }
+        }
+        if (tree->run) {
+          try {
+            return tree->run(argm, {argv_it, argv.end()});
+          } catch (ShowHelp &) {
+            // note: show help
+          } catch (po::error &e) {
+            fmt::print("{}: {}\n", fmt::join(cmds, " "), e.what());
+            return;
+          } catch (CliError &e) {
+            fmt::print("{}: {}\n", fmt::join(cmds, " "), e.what());
+            return;
+          }
+        }
+      }
+      fmt::print("name:\n  {}\n", fmt::join(cmds, " "));
+      fmt::print("options:\n{}", args.opts);
+      if (!tree->sub.empty()) {
+        fmt::print("subcommands:\n");
+        for (const auto &sub : tree->sub) {
+          fmt::print("  {}\n", sub.first);
+        }
+      }
+      return;
+    }
+  }
+  inline RunResult run(std::string app,
+                       const Tree &tree,
+                       int argc,
+                       const char *argv[]) {
+    return run(std::move(app), tree, {argv + 1, argv + argc});
+  }
+}  // namespace fc::cli

--- a/core/cli/run.hpp
+++ b/core/cli/run.hpp
@@ -23,10 +23,7 @@ namespace fc::cli {
                                         Argv::iterator begin,
                                         Argv::iterator end) {
     po::parsed_options parsed{&opts};
-    while (true) {
-      if (begin == end) {
-        break;
-      }
+    while (begin != end) {
       if (!isDash(*begin)) {
         break;
       }

--- a/core/cli/tree.hpp
+++ b/core/cli/tree.hpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "cli/cli.hpp"
+
+namespace fc::cli {
+  struct Tree {
+    using Sub = std::map<std::string, Tree>;
+    struct Args {
+      std::pair<std::type_index, std::shared_ptr<void>> _;
+      Opts opts;
+    };
+    std::function<Args()> args;
+    std::function<RunResult(ArgsMap &argm, Argv &&argv)> run;
+    Sub sub;
+  };
+  template <typename Cmd>
+  Tree tree(Tree::Sub sub = {}) {
+    Tree t;
+    t.args = [] {
+      const auto ptr{std::make_shared<typename Cmd::Args>()};
+      return Tree::Args{{typeid(typename Cmd::Args), ptr}, ptr->opts()};
+    };
+    constexpr auto run{
+        !std::is_same_v<decltype(Cmd::run), const std::nullptr_t>};
+    if constexpr (run) {
+      t.run = [](ArgsMap &argm, Argv &&argv) {
+        if constexpr (run) {
+          return Cmd::run(argm, argm.of<Cmd>(), std::move(argv));
+        }
+      };
+    }
+    t.sub = std::move(sub);
+    return t;
+  }
+}  // namespace fc::cli

--- a/core/cli/try.hpp
+++ b/core/cli/try.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <boost/optional.hpp>
+
+#include "common/outcome.hpp"
+#include "common/outcome_fmt.hpp"
+
+namespace fc::cli {
+  struct CliError : std::runtime_error {
+    template <typename... Args>
+    CliError(const std::string_view &format, const Args &...args)
+        : runtime_error{fmt::format(format, args...)} {}
+  };
+
+  template <typename R, typename... Args>
+  auto cliTry(outcome::result<R> &&o,
+              const std::string_view &format,
+              const Args &...args) {
+    if (o) {
+      return std::move(o).value();
+    }
+    throw CliError{
+        "{} (error_code: {:#})", fmt::format(format, args...), o.error()};
+  }
+
+  template <typename R>
+  auto cliTry(outcome::result<R> &&o) {
+    return cliTry(std::move(o), "outcome::result");
+  }
+
+  template <typename R, typename... Args>
+  auto cliTry(boost::optional<R> &&o,
+              const std::string_view &format,
+              const Args &...args) {
+    if (o) {
+      return std::move(o).value();
+    }
+    throw CliError{format, args...};
+  }
+
+  template <typename R>
+  auto cliTry(boost::optional<R> &&o) {
+    return cliTry(std::move(o), "boost::optional");
+  }
+}  // namespace fc::cli

--- a/core/cli/try.hpp
+++ b/core/cli/try.hpp
@@ -9,7 +9,7 @@
 #include <fmt/ostream.h>
 #include <boost/optional.hpp>
 
-#include "common/outcome.hpp"
+#include "common/outcome2.hpp"
 #include "common/outcome_fmt.hpp"
 
 namespace fc::cli {
@@ -33,6 +33,18 @@ namespace fc::cli {
   template <typename R>
   auto cliTry(outcome::result<R> &&o) {
     return cliTry(std::move(o), "outcome::result");
+  }
+
+  template <typename R, typename... Args>
+  auto cliTry(Outcome<R> &&o,
+              const std::string_view &format,
+              const Args &...args) {
+    return cliTry(std::move(o.o), format, args...);
+  }
+
+  template <typename R>
+  auto cliTry(Outcome<R> &&o) {
+    return cliTry(std::move(o.o));
   }
 
   template <typename R, typename... Args>

--- a/core/cli/validate/address.hpp
+++ b/core/cli/validate/address.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "cli/validate/with.hpp"
+#include "primitives/address/address_codec.hpp"
+
+namespace fc::primitives::address {
+  CLI_VALIDATE(Address) {
+    return validateWith(out, values, [](const std::string &value) {
+      return decodeFromString(value).value();
+    });
+  }
+}  // namespace fc::primitives::address

--- a/core/cli/validate/cid.hpp
+++ b/core/cli/validate/cid.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "cli/validate/with.hpp"
+#include "primitives/cid/cid.hpp"
+
+namespace fc {
+  CLI_VALIDATE(CID) {
+    return validateWith(out, values, [](const std::string &value) {
+      return CID::fromString(value).value();
+    });
+  }
+}  // namespace fc

--- a/core/cli/validate/peer_info.hpp
+++ b/core/cli/validate/peer_info.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/peer/peer_info.hpp>
+
+#include "cli/validate/with.hpp"
+
+namespace libp2p::peer {
+  CLI_VALIDATE(PeerInfo) {
+    fc::validateWith(out, values, [](const std::string &value) {
+      auto address{multi::Multiaddress::create(value).value()};
+      auto peer{address.getPeerId()};
+      if (!peer) {
+        throw std::exception{};
+      }
+      auto id{PeerId::fromBase58(*peer).value()};
+      return PeerInfo{std::move(id), {std::move(address)}};
+    });
+  }
+}  // namespace libp2p::peer

--- a/core/cli/validate/with.hpp
+++ b/core/cli/validate/with.hpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/program_options/value_semantic.hpp>
+
+#define CLI_VALIDATE(TYPE) \
+  inline void validate(    \
+      boost::any &out, const std::vector<std::string> &values, TYPE *, int)
+
+namespace fc {
+  template <typename F>
+  void validateWith(boost::any &out,
+                    const std::vector<std::string> &values,
+                    const F &f) {
+    namespace po = boost::program_options;
+    po::check_first_occurrence(out);
+    const auto &value{po::get_single_string(values)};
+    try {
+      out = f(value);
+    } catch (...) {
+      boost::throw_exception(po::invalid_option_value{value});
+    }
+  }
+}  // namespace fc

--- a/core/common/libp2p/multi/multiaddress_fmt.hpp
+++ b/core/common/libp2p/multi/multiaddress_fmt.hpp
@@ -1,0 +1,18 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <spdlog/fmt/fmt.h>
+#include <libp2p/multi/multiaddress.hpp>
+
+template <>
+struct fmt::formatter<libp2p::multi::Multiaddress>
+    : formatter<std::string_view> {
+  template <typename C>
+  auto format(const libp2p::multi::Multiaddress &address, C &ctx) {
+    return formatter<std::string_view>::format(address.getStringAddress(), ctx);
+  }
+};

--- a/core/config/profile_config.cpp
+++ b/core/config/profile_config.cpp
@@ -5,6 +5,7 @@
 
 #include "config/profile_config.hpp"
 
+#include "cli/validate/with.hpp"
 #include "const.hpp"
 
 namespace fc::config {
@@ -16,26 +17,14 @@ namespace fc::config {
   /**
    * Checks that profile name is expected one.
    */
-  void validate(boost::any &v,
-                std::vector<std::string> const &values,
-                Profile *,
-                int) {
-    using boost::program_options::validation_error;
-    using boost::program_options::validators::check_first_occurrence;
-    using boost::program_options::validators::get_single_string;
-
-    // Make sure no previous assignment to 'v' was made.
-    check_first_occurrence(v);
-
-    // Extract the first string from 'values'. If there is more than
-    // one string, it's an error, and exception will be thrown.
-    std::string const &value = get_single_string(values);
-    if (value == "mainnet" || value == "2k" || value == "no-upgrades"
-        || value == "interopnet" || value == "butterflynet") {
-      v = boost::any(Profile{value});
-    } else {
-      throw validation_error(validation_error::invalid_option_value);
-    }
+  CLI_VALIDATE(Profile) {
+    validateWith(out, values, [](const std::string &value) {
+      if (value == "mainnet" || value == "2k" || value == "no-upgrades"
+          || value == "interopnet") {
+        return Profile{value};
+      }
+      throw std::exception{};
+    });
   }
 
   options_description configProfile() {

--- a/core/config/profile_config.cpp
+++ b/core/config/profile_config.cpp
@@ -20,7 +20,7 @@ namespace fc::config {
   CLI_VALIDATE(Profile) {
     validateWith(out, values, [](const std::string &value) {
       if (value == "mainnet" || value == "2k" || value == "no-upgrades"
-          || value == "interopnet") {
+          || value == "interopnet" || value == "butterflynet") {
         return Profile{value};
       }
       throw std::exception{};

--- a/core/primitives/address/config.hpp
+++ b/core/primitives/address/config.hpp
@@ -7,8 +7,7 @@
 
 #include <boost/program_options.hpp>
 
-#include "primitives/address/address.hpp"
-#include "primitives/address/address_codec.hpp"
+#include "cli/validate/address.hpp"
 
 namespace fc::primitives::address {
   inline void configCurrentNetwork(
@@ -17,19 +16,5 @@ namespace fc::primitives::address {
            boost::program_options::bool_switch()->notifier([](auto mainnet) {
              currentNetwork = mainnet ? MAINNET : TESTNET;
            }));
-  }
-
-  inline void validate(boost::any &out,
-                       const std::vector<std::string> &values,
-                       Address *,
-                       long) {
-    using namespace boost::program_options;
-    check_first_occurrence(out);
-    auto &value{get_single_string(values)};
-    if (auto address{decodeFromString(value)}) {
-      out = address.value();
-      return;
-    }
-    boost::throw_exception(invalid_option_value{value});
   }
 }  // namespace fc::primitives::address


### PR DESCRIPTION
`bin/fuhon-node-cli`
-  examples (`--version`, `version`, `net connect`, `net listen`, `net peers`).
- `Node::Api` one-line helper (because all cli methods need node api).

cli
- command `Tree` with subcommands.
- `run` with argv to execute command from `Tree`.
- command is struct with typed `Args` and logic in `CLI_RUN`.
- `CLI_OPTS` binds `Args` to `boost::program_options`.
- `ArgsMap` to access parent command `Args` (can be mocked for testing).
- `cliArgv` method to get positional arguments.
- `Empty` and `Group` commands with no `Args` and no logic.

cli opts
- typed `CLI_BOOL` for `--flag` switches.
- typed `CLI_DEFAULT` for `--flag value` options with meaningful/intended default value.
- typed `CLI_OPTIONAL` for `--flag value` options without default value or "required".
- `CLI_OPTIONAL` provides `operator bool`, `operator*`, `operator->` and prints message with name if option was not provided.

cli error
- `CliError` subclass, with formatted message.
- `cliTry` methods to unwrap `outcome` and `optional`, prints formatted message on error.

other
- `CLI_VALIDATE` and `validateWith` for integration with `boost::program_options`.
- fix `api::rpc::loadInfo` order.
- `libp2p::multi::Multiaddress` formatter.