### PR TITLE
timer loop

### DIFF
--- a/core/common/libp2p/timer_loop.hpp
+++ b/core/common/libp2p/timer_loop.hpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/basic/scheduler.hpp>
+
+#include "common/ptr.hpp"
+
+namespace fc {
+  template <typename Cb>
+  void timerLoop(const std::shared_ptr<libp2p::basic::Scheduler> &scheduler,
+                 const std::chrono::milliseconds &interval,
+                 Cb &&cb) {
+    scheduler->schedule(
+        weakCb(scheduler,
+               [interval, cb{std::forward<Cb>(cb)}](
+                   std::shared_ptr<libp2p::basic::Scheduler> &&scheduler) {
+                 cb();
+                 timerLoop(scheduler, interval, std::move(cb));
+               }),
+        interval);
+  }
+}  // namespace fc

--- a/core/common/ptr.hpp
+++ b/core/common/ptr.hpp
@@ -14,12 +14,21 @@ namespace fc {
   std::weak_ptr<T> weaken(const std::shared_ptr<T> &ptr) {
     return ptr;
   }
+  template <typename T>
+  std::weak_ptr<T> weaken(std::weak_ptr<T> &&weak) {
+    return std::move(weak);
+  }
+  template <typename T>
+  std::weak_ptr<T> weaken(std::enable_shared_from_this<T> &ptr) {
+    return ptr.weak_from_this();
+  }
 
-  template <typename T, typename F>
-  auto weakCb0(std::weak_ptr<T> weak, F &&f) {
-    return [weak, f{std::forward<F>(f)}](auto &&...args) {
+  template <typename T, typename Cb>
+  auto weakCb(T &&ptr, Cb &&cb) {
+    return [weak{weaken(std::forward<T>(ptr))},
+            cb{std::forward<Cb>(cb)}](auto &&...args) {
       if (auto ptr{weak.lock()}) {
-        f(std::forward<decltype(args)>(args)...);
+        cb(std::move(ptr), std::forward<decltype(args)>(args)...);
       }
     };
   }

--- a/core/markets/storage/client/impl/storage_market_client_impl.cpp
+++ b/core/markets/storage/client/impl/storage_market_client_impl.cpp
@@ -98,9 +98,10 @@ namespace fc::markets::storage::client {
 
   void StorageMarketClientImpl::askDealStatus(
       const std::shared_ptr<ClientDeal> &deal) {
-    auto cb{weakCb0(
-        weak_from_this(),
-        [=](outcome::result<DealStatusResponseV1_1_0> &&_res) {
+    auto cb{weakCb(
+        *this,
+        [this, deal](std::shared_ptr<StorageMarketClientImpl> &&self,
+                     outcome::result<DealStatusResponseV1_1_0> &&_res) {
           if (_res) {
             auto &res{_res.value()};
             auto state{res.state.status};

--- a/core/node/main/builder.cpp
+++ b/core/node/main/builder.cpp
@@ -36,6 +36,7 @@
 #include "codec/json/json.hpp"
 #include "common/api_secret.hpp"
 #include "common/error_text.hpp"
+#include "common/libp2p/timer_loop.hpp"
 #include "common/peer_key.hpp"
 #include "crypto/bls/impl/bls_provider_impl.hpp"
 #include "crypto/secp256k1/impl/secp256k1_provider_impl.hpp"
@@ -258,23 +259,6 @@ namespace fc::node {
     OUTCOME_TRY(json, codec::json::parse(blob));
     OUTCOME_TRY(key_info, api::decode<KeyInfo>(json));
     return std::move(key_info);
-  }
-
-  /**
-   * Run timer loop
-   * @param scheduler - timer scheduler
-   * @param tick - timer tick
-   * @param cb - callback to call
-   */
-  void timerLoop(const std::shared_ptr<Scheduler> &scheduler,
-                 const std::chrono::milliseconds &tick,
-                 const std::function<void()> &cb) {
-    scheduler->schedule(
-        [scheduler, tick, cb]() {
-          cb();
-          timerLoop(scheduler, tick, cb);
-        },
-        tick);
   }
 
   /**

--- a/core/node/peer_discovery.hpp
+++ b/core/node/peer_discovery.hpp
@@ -41,7 +41,6 @@ namespace fc::sync {
     events::Connection peer_disconnected_event_;
     events::Connection block_pubsub_event_;
     events::Connection message_pubsub_event_;
-    Scheduler::Handle timer_handle_;
     size_t n_connections_ = 0;
     std::unordered_set<libp2p::peer::PeerId> requests_in_progress_;
   };

--- a/core/node/say_hello.hpp
+++ b/core/node/say_hello.hpp
@@ -82,8 +82,6 @@ namespace fc::sync {
     };
 
     std::multiset<TimeAndPeerId> active_requests_by_sent_time_;
-
-    Scheduler::Handle heartbeat_handle_;
   };
 
 }  // namespace fc::sync

--- a/core/sector_storage/stores/impl/local_store.cpp
+++ b/core/sector_storage/stores/impl/local_store.cpp
@@ -8,7 +8,6 @@
 #include <boost/filesystem.hpp>
 #include <chrono>
 #include <ctime>
-#include <libp2p/basic/scheduler.hpp>
 #include <map>
 #include <random>
 #include <regex>
@@ -17,6 +16,7 @@
 #include "api/rpc/json.hpp"
 #include "codec/json/json.hpp"
 #include "common/file.hpp"
+#include "common/libp2p/timer_loop.hpp"
 #include "primitives/sector_file/sector_file.hpp"
 #include "sector_storage/stores/impl/util.hpp"
 #include "sector_storage/stores/storage_error.hpp"
@@ -25,7 +25,6 @@
 namespace fc::sector_storage::stores {
   using primitives::LocalStorageMeta;
   using primitives::sector_file::kSectorFileTypes;
-  using std::chrono::duration_cast;
   namespace fs = boost::filesystem;
 
   outcome::result<SectorId> parseSectorId(const std::string &filename) {
@@ -390,14 +389,11 @@ namespace fc::sector_storage::stores {
     for (const auto &path : config->storage_paths) {
       OUTCOME_TRY(local->openPath(path.path));
     }
-    local->handler_ = scheduler->scheduleWithHandle(
-        [self = std::weak_ptr<LocalStoreImpl>(local)]() {
-          auto shared_self = self.lock();
-          if (shared_self) {
-            shared_self->reportHealth();
-          }
-        },
-        local->heartbeat_interval_);
+    timerLoop(scheduler,
+              local->heartbeat_interval_,
+              weakCb(local, [](std::shared_ptr<LocalStoreImpl> &&self) {
+                self->reportHealth();
+              }));
     return std::move(local);
   }
 
@@ -540,9 +536,6 @@ namespace fc::sector_storage::stores {
                       maybe_error.error().message());
       }
     }
-
-    // reschedule during scheduler callback, will not throw
-    handler_.reschedule(heartbeat_interval_).value();
   }
 
   outcome::result<FsStat> LocalStoreImpl::Path::getStat(

--- a/core/sector_storage/stores/impl/local_store.hpp
+++ b/core/sector_storage/stores/impl/local_store.hpp
@@ -82,7 +82,6 @@ namespace fc::sector_storage::stores {
     std::vector<std::string> urls_;
     std::unordered_map<StorageID, std::shared_ptr<Path>> paths_;
     fc::common::Logger logger_;
-    Scheduler::Handle handler_;
     std::chrono::milliseconds heartbeat_interval_;
     mutable std::shared_mutex mutex_;
   };

--- a/core/storage/ipfs/graphsync/impl/network/peer_context.hpp
+++ b/core/storage/ipfs/graphsync/impl/network/peer_context.hpp
@@ -151,6 +151,8 @@ namespace fc::storage::ipfs::graphsync {
 
     void checkResponders();
 
+    void scheduleCleanup(std::chrono::milliseconds delay);
+
     /// Remote peer
     const PeerId peer_;
 
@@ -183,9 +185,6 @@ namespace fc::storage::ipfs::graphsync {
 
     /// Active streams being read
     Streams streams_;
-
-    /// Scheduler's handle, expiration timer
-    Scheduler::Handle timer_;
 
     /// Flag, indicates that peer is closed
     bool closed_ = false;

--- a/core/storage/ipld/cids_ipld.cpp
+++ b/core/storage/ipld/cids_ipld.cpp
@@ -244,7 +244,7 @@ namespace fc::storage::ipld {
   void CidsIpld::asyncFlush() {
     if (!flushing.test_and_set()) {
       if (io) {
-        io->post(weakCb0(weak_from_this(), [this] {
+        io->post(weakCb(*this, [this](std::shared_ptr<CidsIpld> &&self) {
           if (auto r{doFlush()}; !r) {
             spdlog::error("CidsIpld({}) async flush: {:#}", index_path, ~r);
           }


### PR DESCRIPTION
- `timerLoop` - don't keep scheduler handle if you need only repeating timer
  - "stop" can be added with callback return value, e.g. stop on "false".
  - "stop" isn't implemented currently as `timerLoop` is only used by "singleton" components, so timers are not leaked (e.g. if `timerLoop` was called for each client connection, and those timers wouldn't stop)
- `weaken` - convert pointer to corresponding weak pointer
- `weakCb` - most callbacks do nothing when weak pointer expires