### PR TITLE
clang++-9 link in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN curl -sL https://golang.org/dl/go1.17.3.linux-amd64.tar.gz | tar -xz -C /usr
 ENV PATH="$PATH:/usr/local/go/bin"
 COPY . /tmp/cpp-filecoin
 RUN git -C /tmp/cpp-filecoin submodule update --init --recursive
+RUN ln -s /usr/bin/clang++-9 /usr/bin/clang++
 RUN --mount=type=cache,target=/tmp/.hunter/_Base/Cache CC=clang-9 CXX=clang++-9 cmake /tmp/cpp-filecoin -B /tmp/build -G Ninja -D CMAKE_BUILD_TYPE=Release -D TESTING=OFF
 RUN --mount=type=cache,target=/tmp/.hunter/_Base/Cache CC=clang-9 cmake --build /tmp/build --target fuhon-node fuhon-miner
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN curl -sL https://golang.org/dl/go1.17.3.linux-amd64.tar.gz | tar -xz -C /usr
 ENV PATH="$PATH:/usr/local/go/bin"
 COPY . /tmp/cpp-filecoin
 RUN git -C /tmp/cpp-filecoin submodule update --init --recursive
+RUN ln -s /usr/bin/clang++-9 /usr/bin/clang++
 RUN --mount=type=cache,target=/tmp/.hunter/_Base/Cache CC=clang-9 CXX=clang++-9 cmake /tmp/cpp-filecoin -B /tmp/build -G Ninja -D CMAKE_BUILD_TYPE=Release -D TESTING=OFF
 RUN --mount=type=cache,target=/tmp/.hunter/_Base/Cache CC=clang-9 cmake --build /tmp/build --target fuhon-node fuhon-miner
 


### PR DESCRIPTION
Signed-off-by: Alexey Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
The problem is that Hunter builds Boost as dependency and cannot find compiler `clang++` for it. Actually, compiler is installed as clang-9 and Cmake declares compiler as `clang++-9` which is located at `/usr/bin/clang++-9`. The straigtforward solution is to make a link, but I don't think it is a best one.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
